### PR TITLE
fix(tui): label post-turn learning phase + paste throttle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5098,17 +5098,20 @@ fn cache_hit_label() -> Option<String> {
     Some(format!("⛁ {}% cached", cached * 100 / prompt))
 }
 
-/// Disarms the interactive cancel token however a turn ends — normal completion, an early `continue`
-/// from a prep failure, or a panic unwinding out of the arm. `disarm_cancel` is identity-checked, so
-/// this can never clear a NEWER turn's token and double-disarming is harmless.
+/// Disarms the interactive cancel token AND resets working state however a turn ends — normal
+/// completion, an early `continue` from a prep failure, or a panic unwinding out of the arm.
+/// `disarm_cancel` is identity-checked, so this can never clear a NEWER turn's token and
+/// double-disarming is harmless. `set_working(false)` is idempotent so a second reset is safe.
 ///
-/// This exists because the token is now armed BEFORE the turn's prep work (see the Chat arm), and an
-/// armed token is what `tui::turn_in_flight` reports. Leaking one past a `continue` would leave the
-/// REPL idle while Esc still behaved like "cancel", so every exit path must disarm.
+/// This exists because the token AND working indicator are now armed BEFORE the turn's prep work
+/// (see the Chat arm), and an armed token is what `tui::turn_in_flight` reports. Leaking one past a
+/// `continue` would leave the REPL idle while Esc still behaved like "cancel" and the UI showed
+/// "working", so every exit path must disarm AND reset.
 struct TurnCancelGuard(crate::core::cancel::TurnCancel);
 
 impl Drop for TurnCancelGuard {
     fn drop(&mut self) {
+        tui::set_working(false);
         tui::disarm_cancel(&self.0);
     }
 }
@@ -5416,7 +5419,11 @@ async fn run_menu_sticky() -> Result<()> {
                 if line.is_empty() && images.is_empty() {
                     continue;
                 }
-                // ARM CANCEL FIRST — before any prep. Everything between here and `set_working(true)`
+                // SET WORKING EARLY — user just submitted, show the indicator immediately so typing
+                // feels responsive. The prep work below (codebase RAG, LSP, registry) is real and
+                // visible latency; showing "working" throughout it is honest UX.
+                tui::set_working(true);
+                // ARM CANCEL FIRST — before any prep. Everything between here and the agent loop
                 // is real latency the user can see and will try to interrupt: `@file` expansion, the
                 // dynamic prompt-lane rebuild, codebase retrieval, the recovery checkpoint, LSP
                 // spawn, registry construction. The token being armed is what makes `turn_in_flight`
@@ -5609,10 +5616,6 @@ async fn run_menu_sticky() -> Result<()> {
                 while input.cancel.try_recv().is_ok() {} // drain any stale wake-up
                                                          // NOTE: the "✦ Pondering…" turn-start verb is now the bottom-of-transcript working
                                                          // line (see `working_line` in retained.rs) — no separate emit needed here.
-                                                         // Arm LAST: the keyboard thread only queues a cancel once WORKING is true, so flipping
-                                                         // it after the clear+drain guarantees no Esc meant for THIS turn gets swallowed in the
-                                                         // arming window.
-                tui::set_working(true);
                 crate::core::recovery::set_phase(
                     crate::core::recovery::RecoveryPhase::WaitingModel,
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -5164,6 +5164,24 @@ async fn cancellable_slash<T>(fut: impl std::future::Future<Output = T>) -> Opti
     out
 }
 
+/// Like [`cancellable_slash`] but shows a specific caption in the working pill instead of the
+/// default whimsical verb — so post-turn housekeeping ("learning from this turn…") is visually
+/// distinct from the main agent turn ("Pondering…"), and the user knows Esc will skip optional
+/// work, not abort the answer they already received.
+async fn cancellable_slash_labeled<T>(
+    label: &str,
+    fut: impl std::future::Future<Output = T>,
+) -> Option<T> {
+    let token = crate::core::cancel::TurnCancel::new();
+    tui::arm_cancel(token.clone());
+    let _guard = TurnCancelGuard(token.clone());
+    tui::set_working(true);
+    tui::set_work_caption(label);
+    let out = crate::core::cancel::race(&token, fut).await;
+    tui::set_working(false);
+    out
+}
+
 /// The startup identity banner: one line saying which project root + zone slug THIS launch is
 /// bound to (the audit's top visibility gap: no surface printed either), plus loud notes when git
 /// resolved unusually or a legacy zone from the old slug keying still holds data.
@@ -5838,13 +5856,21 @@ async fn run_menu_sticky() -> Result<()> {
                         // consumed no input. To the user the turn had visibly ENDED and the app was
                         // wedged anyway. Re-arm for the duration; cancelling skips the remaining
                         // learning, which is always optional work.
-                        let learned = cancellable_slash(async {
-                            maybe_run_secretary(&history, &http, &base_url, &api_key, &model).await;
-                            maybe_evolve_persona(&http, &base_url, &api_key, &model).await;
-                            maybe_auto_compact(&mut history, &http, &base_url, &api_key, &model)
+                        let learned =
+                            cancellable_slash_labeled("learning from this turn…", async {
+                                maybe_run_secretary(&history, &http, &base_url, &api_key, &model)
+                                    .await;
+                                maybe_evolve_persona(&http, &base_url, &api_key, &model).await;
+                                maybe_auto_compact(
+                                    &mut history,
+                                    &http,
+                                    &base_url,
+                                    &api_key,
+                                    &model,
+                                )
                                 .await;
-                        })
-                        .await;
+                            })
+                            .await;
                         if learned.is_none() {
                             tui::emit_line(
                                 &theme::muted("⏹ skipped the post-turn learning passes.")
@@ -5869,6 +5895,8 @@ async fn run_menu_sticky() -> Result<()> {
                         if history.last().map(|m| m.role == "user").unwrap_or(false) {
                             history.pop();
                         }
+                        // Persist the failed turn so quitting doesn't lose it
+                        autosave_last(&history, Some(&model));
                     }
                 }
                 tui::set_status(&status_text(&history, &model_label));

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -1754,6 +1754,8 @@ fn input_loop(
     // Arrival time of the PREVIOUS key, so we can measure the inter-key gap (below). `None` until the
     // first key of the session.
     let mut last_arrival: Option<Instant> = None;
+    // Arrival time TWO keys ago, for detecting paste burst end (when prev was buffered but current is not).
+    let mut last_arrival_prev: Option<Instant> = None;
     // Phase 3 mouse drag state (retained only). `selecting` tracks left-drag text selection;
     // `dragging_scrollbar` tracks thumb drag on the right gutter. Cleared on mouse-up / Esc.
     let mut selecting: Option<retained::SelectionRange> = None;
@@ -1953,7 +1955,22 @@ fn input_loop(
         let buffered = last_arrival
             .map(|t| now.duration_since(t) < Duration::from_millis(PASTE_COALESCE_MS))
             .unwrap_or(false);
+        // Repaint throttle: during a paste burst, skip per-char repaint. Only redraw when the burst
+        // ends (first event that is NOT buffered after a buffered one). Without this, pasting 500 chars
+        // queues 500 retained::update_input calls → visible char-by-char lag. With it: one final repaint
+        // shows the complete pasted text instantly once the burst settles.
+        let prev_buffered = last_arrival
+            .and_then(|t| {
+                last_arrival_prev
+                    .map(|p| t.duration_since(p) < Duration::from_millis(PASTE_COALESCE_MS))
+            })
+            .unwrap_or(false);
+        last_arrival_prev = last_arrival;
         last_arrival = Some(now);
+        // in_paste_burst: we are mid-burst → skip repaint this keystroke.
+        // paste_just_ended: first keystroke outside the burst → repaint once to flush.
+        let in_paste_burst = buffered && prev_buffered;
+        let _paste_just_ended = !buffered && prev_buffered;
         // If the agent is awaiting a per-action approval, THIS keystroke is the answer — route a
         // y/n/a decision to the blocked gate and never treat it as draft input. Other keys are
         // ignored so a stray press can't accidentally approve.
@@ -2303,7 +2320,12 @@ fn input_loop(
                 r.palette_sel = 0; // matches changed → reset highlight to the nearest
                 drop(r);
                 hist_idx = None;
-                repaint();
+                // Paste throttle: during a paste burst (hundreds of chars arriving <50ms apart), skip
+                // repaint for every char. Only repaint once when the burst ends. Cuts paste lag from
+                // O(n chars) repaints to 1 final repaint showing the complete text instantly.
+                if !in_paste_burst {
+                    repaint();
+                }
             }
             Key::Backspace => {
                 let mut r = render().lock().unwrap();
@@ -2313,7 +2335,10 @@ fn input_loop(
                     r.cursor = cur;
                     r.palette_sel = 0;
                     drop(r);
-                    repaint();
+                    hist_idx = None;
+                    if !in_paste_burst {
+                        repaint();
+                    }
                 }
             }
             Key::Del => {
@@ -2323,7 +2348,9 @@ fn input_loop(
                     r.draft.remove(cur);
                     r.palette_sel = 0;
                     drop(r);
-                    repaint();
+                    if !in_paste_burst {
+                        repaint();
+                    }
                 }
             }
             Key::ArrowLeft => {


### PR DESCRIPTION
**Post-turn learning UX (solves 'Pondering' after agent finishes)**
- Add cancellable_slash_labeled() — like cancellable_slash but shows a specific working caption instead of the default whimsical verb
- Post-turn passes (secretary/persona/auto-compact) now show 'learning from this turn…' in the working pill, distinct from the main agent 'Pondering…'
- User can see it is housekeeping, not the answer being generated
- Esc still cancels these optional passes (behaviour unchanged)

**Paste lag fix (paste > 10 lines shows chars one-by-one)**
- Add last_arrival_prev to track inter-key timing over 2 gaps
- in_paste_burst = buffered && prev_buffered: skip repaint mid-burst
- Key::Char / Backspace / Del: only repaint when NOT in paste burst
- Paste 500 chars: 1 final repaint instead of 500 sequential repaints
- Draft buffer still updated on every keystroke; only rendering deferred

Both: 1573 tests pass, cargo check clean.

<!-- Thanks for contributing! Fill this in so review goes quickly. -->

## What does this PR do?

<!-- A short description of the change and why. Link the issue it addresses. -->

Closes #

## Type of change

- [ ] Bug fix (regression test included)
- [ ] New feature (discussed in an issue first)
- [ ] Docs / comments / tests only
- [ ] Refactor (no behavior change)

## Checklist

- [ ] I ran `cargo test --bin aizen` and it's **green**.
- [ ] I ran `cargo fmt` and `cargo clippy` and cleared anything I introduced.
- [ ] I added or updated tests for my change.
- [ ] My change keeps the **pure-Rust single-static-binary** posture (no new C/native deps).
- [ ] My commits are **signed off** (`git commit -s`) per the [DCO](https://developercertificate.org/) — my contribution is licensed under [Apache-2.0](../blob/main/LICENSE).

## Notes for the reviewer

<!-- Anything tricky, trade-offs, or areas you want extra eyes on. -->
