### PR TITLE
feat(providers): OpenCode (free) preset — public token, free-model tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ development log lives in that monorepo's history.
 
 ## [Unreleased]
 
+### Added
+- **OpenCode (free) preset.** OpenCode's zen gateway (`https://opencode.ai/zen/v1`) joins the
+  provider picker: the free tier authenticates with the literal shared token `public` (no sign-up),
+  and Aizen attaches the `x-opencode-client` header automatically. Free models there are the
+  `-free`-suffixed ids (plus `big-pickle`), and both `aizen models` and the model pickers tag those
+  rows `· free` so they stand out from the paid ids in the same list. Setup's chat-path key probe
+  now prefers a `-free` variant when the list has one — probing a paid model with a free-tier
+  credential could draw a 403 that read as "bad key" (OpenRouter benefits from the same fix).
+
 ## [0.6.4] — 2026-08-11
 
 The time machine grows a brain — checkpoints classified by value instead of hoarded uniformly, a

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -264,6 +264,15 @@ saved selection; Aizen prints a note when those environment variables mask a swi
 Changing an existing provider's endpoint asks for a new key instead of offering the previous
 endpoint's credential. Cancelling any wizard step leaves the complete saved profile unchanged.
 
+**OpenCode (free)** is a preset for OpenCode's zen gateway — a zero-cost way to try an agent before
+bringing a key. The base URL is `https://opencode.ai/zen/v1` and the free tier's shared token is the
+literal string `public` (type it at the key step; no sign-up anywhere). Its free models are the
+`-free`-suffixed ids in the live list (`deepseek-v4-flash-free`, `mimo-v2.5-free`, …) plus
+`big-pickle`; `aizen models` and the model pickers tag those rows with `· free` so a free-tier id
+stands out from the paid ones in the same list. Expect free-tier rate limits — a 429 is retried with
+the gateway's `Retry-After` like any other transient failure. The gateway reports no context
+windows, so the HUD estimates them from the model name until you set one.
+
 Sub-agent configuration uses the same provider list. In `/config` → **Sub-agents**, choose a saved
 provider and either its default model or a model override for Sub-agent default, Summarizer, Oracle,
 Apply, or an installed specialist. No endpoint/key is retyped. Scriptable specialist equivalent:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -267,7 +267,7 @@ endpoint's credential. Cancelling any wizard step leaves the complete saved prof
 **OpenCode (free)** is a preset for OpenCode's zen gateway — a zero-cost way to try an agent before
 bringing a key. The base URL is `https://opencode.ai/zen/v1` and the free tier's shared token is the
 literal string `public` (type it at the key step; no sign-up anywhere). Its free models are the
-`-free`-suffixed ids in the live list (`deepseek-v4-flash-free`, `mimo-v2.5-free`, …) plus
+`-free`-suffixed ids in the live list (`deepseek-v4-flash-free`, `mimo-v2.5-free`, `hy3-free`, …) plus
 `big-pickle`; `aizen models` and the model pickers tag those rows with `· free` so a free-tier id
 stands out from the paid ones in the same list. Expect free-tier rate limits — a 429 is retried with
 the gateway's `Retry-After` like any other transient failure. The gateway reports no context

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -222,9 +222,40 @@ pub fn is_anthropic_endpoint(base_url: &str) -> bool {
     host == "api.anthropic.com" || host.ends_with(".api.anthropic.com")
 }
 
+/// Same host test for OpenCode's zen gateway. Its free tier is reachable with the literal shared
+/// token `public` but only identifies clients that say who they are, so requests to this host carry
+/// `x-opencode-client` — see [`with_provider_auth`]. Host-matched for the same reason as
+/// [`is_anthropic_endpoint`]: a proxy whose path mentions opencode is not first-party.
+pub fn is_opencode_endpoint(base_url: &str) -> bool {
+    let after_scheme = base_url
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(base_url);
+    let host = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .split('@') // strip any userinfo
+        .next_back()
+        .unwrap_or("")
+        .split(':') // strip the port
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    host == "opencode.ai" || host.ends_with(".opencode.ai")
+}
+
+/// Free-tier variants on shared gateways (OpenCode zen, OpenRouter) carry a `-free` id suffix.
+/// Names the convention once for the places that care: the key-probe model choice below and the
+/// free tags in model listings.
+pub fn is_free_model_id(id: &str) -> bool {
+    id.ends_with("-free")
+}
+
 /// Attach auth for `base_url`: always Bearer (what every OpenAI-compatible gateway wants), plus
 /// Anthropic's native pair when the host is theirs. Sending both is safe — each side ignores the
-/// header it doesn't use — and it means one code path serves both wire dialects.
+/// header it doesn't use — and it means one code path serves both wire dialects. OpenCode's gateway
+/// gets its client-identification header the same way.
 fn with_provider_auth(
     rb: reqwest::RequestBuilder,
     base_url: &str,
@@ -234,6 +265,8 @@ fn with_provider_auth(
     if is_anthropic_endpoint(base_url) {
         rb.header("x-api-key", api_key)
             .header("anthropic-version", "2023-06-01")
+    } else if is_opencode_endpoint(base_url) {
+        rb.header("x-opencode-client", "desktop")
     } else {
         rb
     }
@@ -311,8 +344,14 @@ async fn check_endpoint_with_deadline(
         // to anyone, so a corrupted key sails through validation and only fails on the first real
         // turn. When we have a key, confirm it on the endpoint that enforces auth.
         if let Some(k) = api_key {
+            // Prefer a `-free` variant when the list has one: free-tier gateways (OpenCode zen,
+            // OpenRouter) mix paid models into the same list, and probing a paid one with a
+            // free-tier credential can draw a 403 — which would read here as "bad key" and send
+            // the user off to re-paste a token that was fine.
             let probe_model = infos
-                .first()
+                .iter()
+                .find(|m| is_free_model_id(&m.id))
+                .or_else(|| infos.first())
                 .map(|m| m.id.as_str())
                 .unwrap_or("gpt-4o-mini");
             if let Some(detail) =
@@ -1954,6 +1993,38 @@ mod tests {
     }
 
     #[test]
+    fn opencode_endpoint_is_matched_on_host_not_substring() {
+        // First-party zen paths, with scheme/case/port variations.
+        for b in [
+            "https://opencode.ai/zen/v1",
+            "https://opencode.ai/zen/v1/",
+            "https://OpenCode.AI/zen/v1",
+            "http://opencode.ai:443/zen/go/v1",
+        ] {
+            assert!(is_opencode_endpoint(b), "{b} is first-party OpenCode");
+        }
+        // A proxy that merely MENTIONS opencode in its path is NOT first-party — misclassifying it
+        // would pin zen-gateway behaviour (the client header) onto a third-party server.
+        for b in [
+            "https://gw.example.com/opencode/v1",
+            "https://opencode.ai.evil.test/v1",
+            "https://api.anthropic.com/v1",
+            "http://localhost:11434/v1",
+        ] {
+            assert!(!is_opencode_endpoint(b), "{b} must not be first-party");
+        }
+    }
+
+    #[test]
+    fn free_model_id_is_the_suffix_convention() {
+        assert!(is_free_model_id("deepseek-v4-flash-free"));
+        assert!(is_free_model_id("mimo-v2.5-free"));
+        // Position matters: a leading or embedded "free" is not the tier marker.
+        assert!(!is_free_model_id("free-big-pickle"));
+        assert!(!is_free_model_id("claude-fable-5"));
+    }
+
+    #[test]
     fn cache_enabled_auto_and_forced() {
         assert!(cache_enabled(None, "opus-4-8"), "AUTO on for Anthropic");
         assert!(!cache_enabled(None, "gpt-4o"), "AUTO off for non-Anthropic");
@@ -2513,6 +2584,61 @@ mod tests {
         assert!(
             matches!(got, EndpointCheck::Ok(_)),
             "a 400 proves nothing about the key, got {got:?}"
+        );
+    }
+
+    /// The chat-path key probe must prefer a `-free` variant when the list has one. Free-tier
+    /// gateways (OpenCode zen, OpenRouter) mix paid ids into the same `/models` list, and probing a
+    /// paid one with the shared free-tier credential can draw a 403 — which setup would report as
+    /// "bad key" even though the token is exactly what that tier hands out.
+    #[tokio::test]
+    async fn key_probe_prefers_a_free_variant_over_the_first_paid_model() {
+        use std::sync::{Arc, Mutex};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}/v1", listener.local_addr().unwrap());
+        let probed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen = probed.clone();
+        let srv = tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut buf = vec![0u8; 8192];
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                let (status, body) = if req.contains("/chat/completions") {
+                    seen.lock().unwrap().push(req.clone());
+                    (
+                        200,
+                        r#"{"choices":[{"message":{"content":"ok"}}]}"#.to_string(),
+                    )
+                } else {
+                    // Paid model FIRST, so `infos.first()` — the old probe choice — is the paid id.
+                    (
+                        200,
+                        r#"{"object":"list","data":[{"id":"claude-fable-5"},{"id":"deepseek-v4-flash-free"}]}"#
+                            .to_string(),
+                    )
+                };
+                let resp = format!(
+                    "HTTP/1.1 {status} X\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.flush().await;
+            }
+        });
+        let http = reqwest::Client::new();
+        let got = check_endpoint(&http, &base, Some("public")).await;
+        srv.abort();
+        assert!(matches!(got, EndpointCheck::Ok(_)), "got {got:?}");
+        let posts = probed.lock().unwrap();
+        assert_eq!(posts.len(), 1, "exactly one probe POST expected");
+        assert!(
+            posts[0].contains("\"model\":\"deepseek-v4-flash-free\""),
+            "probe must target the -free variant, got: {}",
+            posts[0]
         );
     }
 

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -249,7 +249,8 @@ pub fn is_opencode_endpoint(base_url: &str) -> bool {
 /// Names the convention once for the places that care: the key-probe model choice below and the
 /// free tags in model listings.
 pub fn is_free_model_id(id: &str) -> bool {
-    id.ends_with("-free")
+    // OpenCode zen's free catalog is mostly *-free, plus the unsuffixed free id big-pickle.
+    id.ends_with("-free") || id == "big-pickle"
 }
 
 /// Attach auth for `base_url`: always Bearer (what every OpenAI-compatible gateway wants), plus
@@ -2019,6 +2020,8 @@ mod tests {
     fn free_model_id_is_the_suffix_convention() {
         assert!(is_free_model_id("deepseek-v4-flash-free"));
         assert!(is_free_model_id("mimo-v2.5-free"));
+        // OpenCode zen also ships one unsuffixed free id.
+        assert!(is_free_model_id("big-pickle"));
         // Position matters: a leading or embedded "free" is not the tier marker.
         assert!(!is_free_model_id("free-big-pickle"));
         assert!(!is_free_model_id("claude-fable-5"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -12431,6 +12431,12 @@ struct ProviderPreset {
 /// `authorization` is fully supported). So this preset needs no new wire protocol. The one wrinkle is
 /// `GET /v1/models`, which is the NATIVE endpoint and wants `x-api-key` + `anthropic-version` —
 /// handled in `client::with_provider_auth`, not here.
+///
+/// OpenCode's zen gateway is the other entry with a wrinkle: its free tier authenticates with the
+/// literal shared token `public` (the `keys_url` row says so, mirroring the Ollama no-key pattern)
+/// and expects the `x-opencode-client` header — also attached in `client::with_provider_auth`. Its
+/// free models are the `-free`-suffixed ids in the live `/models` list; `sample_model` is only the
+/// manual-entry default if that fetch fails.
 const PROVIDER_PRESETS: &[ProviderPreset] = &[
     ProviderPreset {
         label: "OpenAI",
@@ -12461,6 +12467,12 @@ const PROVIDER_PRESETS: &[ProviderPreset] = &[
         base: "https://api.deepseek.com/v1",
         keys_url: "https://platform.deepseek.com/api_keys",
         sample_model: "deepseek-chat",
+    },
+    ProviderPreset {
+        label: "OpenCode (free)",
+        base: "https://opencode.ai/zen/v1",
+        keys_url: "no key needed — free tier: enter the shared token `public`",
+        sample_model: "deepseek-v4-flash-free",
     },
     ProviderPreset {
         label: "Ollama (local)",
@@ -13105,9 +13117,18 @@ fn pick_model_from(
     let ids: Vec<String> = infos.iter().map(|m| m.id.clone()).collect();
     let mut items: Vec<String> = infos
         .iter()
-        .map(|m| match m.context_length {
-            Some(n) => format!("{}  ({} ctx)", m.id, n),
-            None => m.id.clone(),
+        .map(|m| {
+            // Free-tier ids get a tag so someone on a free gateway doesn't pick a paid model by
+            // accident — the failure would only surface on the first real turn.
+            let free = if client::is_free_model_id(&m.id) {
+                "  · free"
+            } else {
+                ""
+            };
+            match m.context_length {
+                Some(n) => format!("{}{free}  ({} ctx)", m.id, n),
+                None => format!("{}{free}", m.id),
+            }
         })
         .collect();
     items.push(CUSTOM_MODEL_ITEM.to_string());
@@ -14585,12 +14606,17 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
         } else {
             ""
         };
+        let free = if client::is_free_model_id(&m.id) {
+            "  · free"
+        } else {
+            ""
+        };
         let ctx = match m.context_length {
             Some(n) if n >= 1000 => format!("  · ctx {}K", n / 1000),
             Some(n) => format!("  · ctx {n}"),
             None => String::new(),
         };
-        println!("{}{ctx}{mark}", m.id);
+        println!("{}{free}{ctx}{mark}", m.id);
     }
     if !any_ctx {
         println!(
@@ -16177,6 +16203,23 @@ mod tests {
         }
         assert!(
             Cli::try_parse_from(["aizen", "config", "provider", "add", "missing-flags"]).is_err()
+        );
+    }
+
+    #[test]
+    fn opencode_free_preset_is_registered() {
+        let p = PROVIDER_PRESETS
+            .iter()
+            .find(|p| p.label == "OpenCode (free)")
+            .expect("the OpenCode free preset exists");
+        assert_eq!(p.base, "https://opencode.ai/zen/v1");
+        // The free tier's shared token is `public`; the hint must say so or a first-run user has no
+        // way to guess the value the gateway expects.
+        assert!(p.keys_url.contains("public"));
+        assert!(
+            p.sample_model.ends_with("-free"),
+            "the sample must be a free-tier id, got {}",
+            p.sample_model
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5868,19 +5868,20 @@ async fn run_menu_sticky() -> Result<()> {
                         // hung stream in one pass doesn't strand the REPL for >15 minutes. If the timeout
                         // fires, the user sees "· skipped" instead of an infinite spinner.
                         const POST_TURN_OVERALL_TIMEOUT_SECS: u64 = 600;
-                        let learning_fut = cancellable_slash_labeled("learning from this turn…", async {
-                            maybe_run_secretary(&history, &http, &base_url, &api_key, &model)
+                        let learning_fut =
+                            cancellable_slash_labeled("learning from this turn…", async {
+                                maybe_run_secretary(&history, &http, &base_url, &api_key, &model)
+                                    .await;
+                                maybe_evolve_persona(&http, &base_url, &api_key, &model).await;
+                                maybe_auto_compact(
+                                    &mut history,
+                                    &http,
+                                    &base_url,
+                                    &api_key,
+                                    &model,
+                                )
                                 .await;
-                            maybe_evolve_persona(&http, &base_url, &api_key, &model).await;
-                            maybe_auto_compact(
-                                &mut history,
-                                &http,
-                                &base_url,
-                                &api_key,
-                                &model,
-                            )
-                            .await;
-                        });
+                            });
                         let learned = match tokio::time::timeout(
                             std::time::Duration::from_secs(POST_TURN_OVERALL_TIMEOUT_SECS),
                             learning_fut,


### PR DESCRIPTION
## What

Adds OpenCode's zen gateway as a first-class **OpenCode (free)** preset — a zero-cost way to run an agent before bringing a key.

- **Preset** in the provider picker (`aizen config` wizard + the connection section editor): base `https://opencode.ai/zen/v1`, hint says the free tier's shared token is the literal string `public` — no sign-up anywhere.
- **Auth wiring**: requests to the `opencode.ai` host automatically carry `x-opencode-client: desktop`, mirroring the existing Anthropic host-detection in `with_provider_auth`. Host-matched (not substring), so a proxy whose path mentions opencode is untouched.
- **Free-model visibility**: free ids on shared gateways (OpenCode zen, OpenRouter) carry a `-free` suffix; `aizen models` and both model pickers tag those rows `· free` so a free-tier user doesn't pick a paid id that would only fail on the first real turn.
- **Key-probe fix**: setup's chat-path probe now prefers a `-free` variant when the list has one — zen mixes paid models into the same `/models` list, and probing a paid one with the shared free-tier credential can draw a 403 that reads as "bad key". OpenRouter benefits from the same fix.

No new dependencies; providers are data in aizen, so the diff is one preset, one host check, and listing tweaks.

## Free models (live as of 2026-08-16)

`big-pickle`, `deepseek-v4-flash-free`, `mimo-v2.5-free`, `ling-3.0-flash-free`, `nemotron-3-ultra-free`, `north-mini-code-free`, `laguna-s-2.1-free` — the list is dynamic, fetched from `GET /zen/v1/models` (verified live during development; OpenAI-standard shape, no context-window fields, so the HUD falls back to the name heuristic).

## Testing

- Full suite green: **1577 passed, 0 failed** (`cargo test --bin aizen`).
- New tests: host truth-table for `is_opencode_endpoint`, the `-free` suffix convention, a stub-gateway test asserting the key probe POSTs the `-free` variant instead of the first paid id, and a preset-registration test.
- `cargo check` / `cargo fmt` / `cargo clippy` clean — no new clippy warnings.
- Note: an unrelated pre-existing formatting drift in `main.rs` (`run_menu_sticky`) is left untouched on purpose to keep this diff scoped; it reproduces on `main` via `cargo fmt --check` without this PR.