### PR TITLE
feat(providers): experimental ChatGPT Codex OAuth + Responses backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ development log lives in that monorepo's history.
   rows `· free` so they stand out from the paid ids in the same list. Setup's chat-path key probe
   now prefers a `-free` variant when the list has one — probing a paid model with a free-tier
   credential could draw a 403 that read as "bad key" (OpenRouter benefits from the same fix).
+- **ChatGPT Codex OAuth (experimental).** `aizen auth login|status|logout codex` browser PKCE; Codex Responses backend for the agent loop. Kill-switch `AIZEN_DISABLE_CODEX=1`. Private/compatibility surface — see docs RISK.
 
 ## [0.6.4] — 2026-08-11
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -212,7 +212,10 @@ It needs a CNI that enforces NetworkPolicy (Calico, Cilium, Antrea); on a cluste
 object is accepted and enforces nothing. The manifest also sets `automountServiceAccountToken: false`,
 since a shell that can read the projected token can talk to the API server as the pod.
 
-## Configure
+## Config
+
+**ChatGPT Codex (experimental)** uses ChatGPT/Codex *consumer* OAuth (not the OpenAI Platform API key). Run `aizen auth login codex`, then pick the preset (base `https://chatgpt.com/backend-api/codex`) or `aizen config set --base-url https://chatgpt.com/backend-api/codex --api-key codex-oauth --model gpt-5.4-mini`. Tokens live in `~/.aizen/provider-tokens/codex.json`. Kill-switch: `AIZEN_DISABLE_CODEX=1`. **Risk:** private backend APIs may break or conflict with vendor terms; prefer Platform API keys / OpenRouter for supported production use. Logout: `aizen auth logout codex`.
+ure
 
 All network commands read three settings, as flags or env vars:
 

--- a/src/core/cli_config.rs
+++ b/src/core/cli_config.rs
@@ -571,9 +571,16 @@ impl ProviderProfile {
             anyhow::bail!("provider base URL must start with http:// or https://");
         }
         let api_key = api_key.trim();
-        if api_key.is_empty() {
+        // Codex OAuth profiles store tokens out-of-band; api_key may be a placeholder.
+        let codex = crate::llm::oauth_codex::is_codex_base_url(base_url);
+        if api_key.is_empty() && !codex {
             anyhow::bail!("provider API key must not be empty");
         }
+        let api_key = if api_key.is_empty() && codex {
+            "codex-oauth"
+        } else {
+            api_key
+        };
         let model = model.trim();
         if model.is_empty() {
             anyhow::bail!("provider model must not be empty");

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -1044,6 +1044,15 @@ pub async fn chat_with_tools_effort(
     tools: &[ToolDef],
     effort: Option<String>,
 ) -> Result<ChatTurn> {
+    if crate::llm::oauth_codex::is_codex_base_url(base_url) {
+        let _ = api_key;
+        let session = std::env::var("AIZEN_CODEX_SESSION")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| format!("aizen-{}-{model}", std::process::id()));
+        return crate::llm::responses_codex::stream_turn(client, model, messages, tools, &session)
+            .await;
+    }
     let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
     let cfg = crate::core::cli_config::load();
     let mut msgs = messages.to_vec();
@@ -1333,6 +1342,16 @@ pub async fn stream_chat_with_tools_eager(
     tools: &[ToolDef],
     eager_hook: Option<EagerStartFn<'_>>,
 ) -> Result<ChatTurn> {
+    // Experimental ChatGPT Codex path — full Responses dialect (not /chat/completions).
+    if crate::llm::oauth_codex::is_codex_base_url(base_url) {
+        let _ = (api_key, &eager_hook); // bearer comes from the OAuth token store
+        let session = std::env::var("AIZEN_CODEX_SESSION")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| format!("aizen-{}-{model}", std::process::id()));
+        return crate::llm::responses_codex::stream_turn(client, model, messages, tools, &session)
+            .await;
+    }
     let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
     let cfg = crate::core::cli_config::load();
     let mut msgs = messages.to_vec();

--- a/src/llm/codex_models.rs
+++ b/src/llm/codex_models.rs
@@ -1,0 +1,65 @@
+//! Static ChatGPT Codex model catalog (experimental).
+//!
+//! The Codex backend does not expose a stable OpenAI-style GET /models list for free-tier
+//! discovery the way Platform API does, so the picker uses this curated catalog. Update when
+//! upstream renames ids (comment the as-of date in CHANGELOG).
+
+/// (id, short label)
+pub const CODEX_MODELS: &[(&str, &str)] = &[
+    ("gpt-5.6-sol", "GPT 5.6 Sol"),
+    ("gpt-5.6-terra", "GPT 5.6 Terra"),
+    ("gpt-5.6-luna", "GPT 5.6 Luna"),
+    ("gpt-5.5", "GPT 5.5"),
+    ("gpt-5.4", "GPT 5.4"),
+    ("gpt-5.4-mini", "GPT 5.4 Mini"),
+    ("gpt-5.3-codex-spark", "GPT 5.3 Codex Spark"),
+    ("gpt-5.3-codex", "GPT 5.3 Codex"),
+    ("gpt-5.2", "GPT 5.2"),
+    ("gpt-5.1", "GPT 5.1"),
+    ("gpt-5", "GPT 5"),
+];
+
+pub fn default_model() -> &'static str {
+    "gpt-5.4-mini"
+}
+
+#[allow(dead_code)]
+pub fn is_known(id: &str) -> bool {
+    let base = strip_effort_suffix(id).0;
+    CODEX_MODELS.iter().any(|(m, _)| *m == base)
+}
+
+/// Strip a trailing reasoning-effort suffix: `model-high` → (`model`, Some("high")).
+pub fn strip_effort_suffix(id: &str) -> (&str, Option<&str>) {
+    const LEVELS: &[&str] = &["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+    for level in LEVELS {
+        let suffix = format!("-{level}");
+        if let Some(base) = id.strip_suffix(&suffix) {
+            if !base.is_empty() {
+                let effort = if *level == "max" { "xhigh" } else { *level };
+                return (base, Some(effort));
+            }
+        }
+    }
+    (id, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effort_suffix_parse() {
+        assert_eq!(
+            strip_effort_suffix("gpt-5.4-high"),
+            ("gpt-5.4", Some("high"))
+        );
+        assert_eq!(
+            strip_effort_suffix("gpt-5.4-max"),
+            ("gpt-5.4", Some("xhigh"))
+        );
+        assert_eq!(strip_effort_suffix("gpt-5.4"), ("gpt-5.4", None));
+        assert!(is_known("gpt-5.4-mini"));
+        assert!(is_known("gpt-5.4-mini-high"));
+    }
+}

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -2,3 +2,6 @@
 //! agent loop, workflow, and one-shot chat ultimately calls through.
 
 pub mod client;
+pub mod codex_models;
+pub mod oauth_codex;
+pub mod responses_codex;

--- a/src/llm/oauth_codex.rs
+++ b/src/llm/oauth_codex.rs
@@ -1,0 +1,740 @@
+//! ChatGPT Codex OAuth (experimental) — browser PKCE against auth.openai.com, tokens on disk.
+//!
+//! This is the ChatGPT/Codex *consumer* login path (not the OpenAI Platform API key flow).
+//! Upstream endpoints and the public Codex CLI client_id are private/compatibility surfaces and
+//! may break or conflict with vendor terms without notice. Gated by user opt-in + RISK notice.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+
+/// Public Codex CLI OAuth client id (no secret; PKCE public client).
+pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+pub const AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
+pub const TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+pub const SCOPE: &str = "openid profile email offline_access";
+/// Codex CLI historically binds this port; we try it first.
+pub const PREFERRED_CALLBACK_PORT: u16 = 1455;
+const AUTH_TIMEOUT: Duration = Duration::from_secs(300);
+const EXPIRY_MARGIN_SECS: i64 = 60;
+/// Refresh this far before expiry when the token lives longer than a day (Codex refresh lead).
+const LONG_REFRESH_LEAD_SECS: i64 = 5 * 24 * 3600;
+
+/// Default Responses API URL used when the active provider is Codex OAuth.
+pub const CODEX_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+/// Sentinel base_url stored in cli-config for Codex OAuth profiles (no /v1 chat suffix).
+pub const CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+
+/// Env kill-switch — when set to 1/true/yes, Codex OAuth is refused.
+pub fn codex_disabled() -> bool {
+    matches!(
+        std::env::var("AIZEN_DISABLE_CODEX")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodexTokenSet {
+    pub access_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    #[serde(default)]
+    pub expires_at: Option<i64>,
+    #[serde(default)]
+    pub id_token: Option<String>,
+    #[serde(default)]
+    pub account_id: Option<String>,
+    #[serde(default)]
+    pub client_id: String,
+    #[serde(default)]
+    pub last_refresh_at: Option<i64>,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+impl CodexTokenSet {
+    pub fn is_expired(&self) -> bool {
+        match self.expires_at {
+            Some(exp) => {
+                let lead = if exp - now() > 24 * 3600 {
+                    LONG_REFRESH_LEAD_SECS
+                        .min(exp - now() - 60)
+                        .max(EXPIRY_MARGIN_SECS)
+                } else {
+                    EXPIRY_MARGIN_SECS
+                };
+                now() >= exp - lead
+            }
+            None => false,
+        }
+    }
+}
+
+fn now() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+pub fn tokens_dir() -> PathBuf {
+    crate::core::config::aizen_home().join("provider-tokens")
+}
+
+pub fn token_path() -> PathBuf {
+    tokens_dir().join("codex.json")
+}
+
+pub fn has_token() -> bool {
+    token_path().is_file()
+}
+
+pub fn load_token() -> Option<CodexTokenSet> {
+    let s = std::fs::read_to_string(token_path()).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+pub fn clear_token() {
+    let _ = std::fs::remove_file(token_path());
+}
+
+pub fn save_token(t: &CodexTokenSet) -> Result<()> {
+    let dir = tokens_dir();
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    let path = token_path();
+    let tmp = path.with_extension("json.tmp");
+    let body = serde_json::to_vec_pretty(t).context("serializing codex token")?;
+    std::fs::write(&tmp, &body).with_context(|| format!("writing {}", tmp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+    }
+    std::fs::rename(&tmp, &path).with_context(|| format!("renaming to {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+fn b64url(data: &[u8]) -> String {
+    const T: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
+        let b2 = chunk.get(2).copied().unwrap_or(0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(T[((n >> 18) & 63) as usize] as char);
+        out.push(T[((n >> 12) & 63) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(T[((n >> 6) & 63) as usize] as char);
+        }
+        if chunk.len() > 2 {
+            out.push(T[(n & 63) as usize] as char);
+        }
+    }
+    out
+}
+
+fn sha256(data: &[u8]) -> [u8; 32] {
+    let d = ring::digest::digest(&ring::digest::SHA256, data);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(d.as_ref());
+    out
+}
+
+fn rand_b64url(n: usize) -> Result<String> {
+    let mut buf = vec![0u8; n];
+    getrandom::getrandom(&mut buf).map_err(|e| anyhow::anyhow!("system RNG unavailable: {e}"))?;
+    Ok(b64url(&buf))
+}
+
+fn pkce() -> Result<(String, String)> {
+    let verifier = rand_b64url(48)?;
+    let challenge = b64url(&sha256(verifier.as_bytes()));
+    Ok((verifier, challenge))
+}
+
+fn open_browser(url: &str) {
+    #[cfg(target_os = "windows")]
+    let _ = std::process::Command::new("cmd")
+        .args(["/C", "start", "", url])
+        .spawn();
+    #[cfg(target_os = "macos")]
+    let _ = std::process::Command::new("open").arg(url).spawn();
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let _ = std::process::Command::new("xdg-open").arg(url).spawn();
+}
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .user_agent("aizen-codex-oauth")
+        .build()
+        .context("building OAuth HTTP client")
+}
+
+/// Build the authorize URL. Spaces in scope are %20 (not '+'), matching Codex CLI.
+pub fn build_authorize_url(redirect_uri: &str, state: &str, code_challenge: &str) -> String {
+    let params = [
+        ("response_type", "code"),
+        ("client_id", CLIENT_ID),
+        ("redirect_uri", redirect_uri),
+        ("scope", SCOPE),
+        ("code_challenge", code_challenge),
+        ("code_challenge_method", "S256"),
+        ("id_token_add_organizations", "true"),
+        ("codex_cli_simplified_flow", "true"),
+        ("originator", "codex_cli_rs"),
+        ("state", state),
+    ];
+    let qs = params
+        .iter()
+        .map(|(k, v)| format!("{k}={}", urlencoding_encode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{AUTHORIZE_URL}?{qs}")
+}
+
+fn urlencoding_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() * 3);
+    for b in s.as_bytes() {
+        match *b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// Pull a ChatGPT account id out of an id_token payload when present.
+pub fn account_id_from_id_token(id_token: &str) -> Option<String> {
+    let payload = id_token.split('.').nth(1)?;
+    let padded = match payload.len() % 4 {
+        2 => format!("{payload}=="),
+        3 => format!("{payload}="),
+        _ => payload.to_string(),
+    };
+    let b64 = padded.replace('-', "+").replace('_', "/");
+    let raw = b64_decode_std(&b64)?;
+    let v: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    // Claim names observed across Codex/ChatGPT id_tokens — first hit wins.
+    for key in [
+        "https://api.openai.com/auth.chatgpt_account_id",
+        "chatgpt_account_id",
+        "account_id",
+        "https://api.openai.com/auth.account_id",
+    ] {
+        if let Some(s) = v.get(key).and_then(|x| x.as_str()) {
+            if !s.is_empty() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    // Nested organizations / auth object fallbacks.
+    if let Some(s) = v
+        .pointer("/https://api.openai.com/auth/chatgpt_account_id")
+        .and_then(|x| x.as_str())
+    {
+        if !s.is_empty() {
+            return Some(s.to_string());
+        }
+    }
+    None
+}
+
+fn b64_decode_std(s: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            b'=' => Some(0),
+            _ => None,
+        }
+    }
+    let bytes = s.as_bytes();
+    if bytes.len() % 4 != 0 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 4 * 3);
+    for chunk in bytes.chunks(4) {
+        let (a, b, c, d) = (
+            val(chunk[0])?,
+            val(chunk[1])?,
+            val(chunk[2])?,
+            val(chunk[3])?,
+        );
+        out.push((a << 2) | (b >> 4));
+        if chunk[2] != b'=' {
+            out.push((b << 4) | (c >> 2));
+        }
+        if chunk[3] != b'=' {
+            out.push((c << 6) | d);
+        }
+    }
+    Some(out)
+}
+
+fn label_from_id_token(id_token: &str) -> Option<String> {
+    let payload = id_token.split('.').nth(1)?;
+    let padded = match payload.len() % 4 {
+        2 => format!("{payload}=="),
+        3 => format!("{payload}="),
+        _ => payload.to_string(),
+    };
+    let b64 = padded.replace('-', "+").replace('_', "/");
+    let raw = b64_decode_std(&b64)?;
+    let v: serde_json::Value = serde_json::from_slice(&raw).ok()?;
+    v.get("email")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string())
+}
+
+async fn respond(sock: &mut tokio::net::TcpStream, message: &str) {
+    let body = format!(
+        "<!doctype html><meta charset=utf-8><title>Aizen</title>         <body style=\"font-family:system-ui;padding:2rem\"><h1>Aizen</h1><p>{message}</p>         <p>You can close this window.</p></body>"
+    );
+    let resp = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = sock.write_all(resp.as_bytes()).await;
+    let _ = sock.flush().await;
+}
+
+async fn bind_callback_listener() -> Result<(tokio::net::TcpListener, u16, bool)> {
+    match tokio::net::TcpListener::bind(("127.0.0.1", PREFERRED_CALLBACK_PORT)).await {
+        Ok(l) => Ok((l, PREFERRED_CALLBACK_PORT, false)),
+        Err(_) => {
+            let l = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .context("binding loopback callback port")?;
+            let port = l.local_addr()?.port();
+            Ok((l, port, true))
+        }
+    }
+}
+
+/// Interactive browser login. Returns the saved token set.
+pub async fn login_interactive() -> Result<CodexTokenSet> {
+    if codex_disabled() {
+        bail!("Codex OAuth disabled via AIZEN_DISABLE_CODEX");
+    }
+    let (listener, port, fallback) = bind_callback_listener().await?;
+    if fallback {
+        eprintln!(
+            "note: port {PREFERRED_CALLBACK_PORT} busy — using ephemeral :{port}. If OpenAI rejects the redirect, free {PREFERRED_CALLBACK_PORT} (other Codex CLI) and retry."
+        );
+    }
+    let redirect_uri = format!("http://127.0.0.1:{port}/auth/callback");
+    let (verifier, challenge) = pkce()?;
+    let state = rand_b64url(16)?;
+    let auth_url = build_authorize_url(&redirect_uri, &state, &challenge);
+
+    eprintln!("Opening browser for ChatGPT / Codex sign-in…");
+    eprintln!("If it does not open, visit:\n{auth_url}\n");
+    open_browser(&auth_url);
+
+    let (mut sock, _) = tokio::time::timeout(AUTH_TIMEOUT, listener.accept())
+        .await
+        .context("timed out waiting for OAuth callback (5 minutes)")?
+        .context("accepting OAuth callback")?;
+    let mut buf = vec![0u8; 8192];
+    let n = sock.read(&mut buf).await.unwrap_or(0);
+    let req = String::from_utf8_lossy(&buf[..n]);
+    let line = req.lines().next().unwrap_or("");
+    // GET /auth/callback?code=...&state=... HTTP/1.1
+    let path = line.split_whitespace().nth(1).unwrap_or("");
+    let q = path.split_once('?').map(|(_, q)| q).unwrap_or("");
+    let mut code: Option<String> = None;
+    let mut got_state: Option<String> = None;
+    let mut err: Option<String> = None;
+    let mut err_desc: Option<String> = None;
+    for pair in q.split('&') {
+        let mut it = pair.splitn(2, '=');
+        let k = it.next().unwrap_or("");
+        let v = it.next().unwrap_or("");
+        let v = urlencoding_decode(v);
+        match k {
+            "code" => code = Some(v),
+            "state" => got_state = Some(v),
+            "error" => err = Some(v),
+            "error_description" => err_desc = Some(v),
+            _ => {}
+        }
+    }
+    if let Some(e) = err {
+        respond(
+            &mut sock,
+            &format!("Sign-in failed: {}", err_desc.as_deref().unwrap_or(&e)),
+        )
+        .await;
+        bail!("OAuth error: {}", err_desc.unwrap_or(e));
+    }
+    if got_state.as_deref() != Some(state.as_str()) {
+        respond(&mut sock, "State mismatch — possible CSRF. Aborted.").await;
+        bail!("OAuth state mismatch (possible CSRF) — aborted");
+    }
+    let code = code.context("callback missing authorization code")?;
+    respond(
+        &mut sock,
+        "Sign-in complete. Return to the terminal — Aizen is saving tokens.",
+    )
+    .await;
+
+    let client = http_client()?;
+    let form = [
+        ("grant_type", "authorization_code"),
+        ("client_id", CLIENT_ID),
+        ("code", code.as_str()),
+        ("redirect_uri", redirect_uri.as_str()),
+        ("code_verifier", verifier.as_str()),
+    ];
+    let resp = client
+        .post(TOKEN_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Accept", "application/json")
+        .form(&form)
+        .send()
+        .await
+        .context("token exchange request")?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        bail!(
+            "token exchange failed: HTTP {status} — {}",
+            truncate(&body, 400)
+        );
+    }
+    let v: serde_json::Value = resp.json().await.context("parsing token JSON")?;
+    let access = v
+        .get("access_token")
+        .and_then(|x| x.as_str())
+        .context("token response missing access_token")?
+        .to_string();
+    let refresh = v
+        .get("refresh_token")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string());
+    let id_token = v
+        .get("id_token")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string());
+    let expires_in = v.get("expires_in").and_then(|x| x.as_u64()).or_else(|| {
+        v.get("expires_in")
+            .and_then(|x| x.as_str())
+            .and_then(|s| s.parse().ok())
+    });
+    let scope = v
+        .get("scope")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string());
+    let account_id = id_token.as_deref().and_then(account_id_from_id_token);
+    let label = id_token.as_deref().and_then(label_from_id_token);
+    let set = CodexTokenSet {
+        access_token: access,
+        refresh_token: refresh,
+        expires_at: expires_in.map(|s| now() + s as i64),
+        id_token,
+        account_id,
+        client_id: CLIENT_ID.to_string(),
+        last_refresh_at: Some(now()),
+        scope,
+        label,
+    };
+    save_token(&set)?;
+    Ok(set)
+}
+
+fn urlencoding_decode(s: &str) -> String {
+    let mut out = Vec::new();
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        match b[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < b.len() => {
+                let h = |c: u8| match c {
+                    b'0'..=b'9' => Some(c - b'0'),
+                    b'a'..=b'f' => Some(c - b'a' + 10),
+                    b'A'..=b'F' => Some(c - b'A' + 10),
+                    _ => None,
+                };
+                if let (Some(hi), Some(lo)) = (h(b[i + 1]), h(b[i + 2])) {
+                    out.push((hi << 4) | lo);
+                    i += 3;
+                } else {
+                    out.push(b[i]);
+                    i += 1;
+                }
+            }
+            c => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.len() <= n {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..n])
+    }
+}
+
+#[derive(Debug)]
+pub enum RefreshOutcome {
+    Ok(CodexTokenSet),
+    /// Refresh token rejected permanently — caller must re-login.
+    ReauthRequired(String),
+    Transient(String),
+}
+
+static REFRESH_LOCK: once_cell::sync::Lazy<Arc<Mutex<()>>> =
+    once_cell::sync::Lazy::new(|| Arc::new(Mutex::new(())));
+
+/// Refresh the access token. Single-flight across the process.
+pub async fn refresh_token(set: &CodexTokenSet) -> RefreshOutcome {
+    let _guard = REFRESH_LOCK.lock().await;
+    // Re-load disk in case another task already refreshed.
+    if let Some(fresh) = load_token() {
+        if !fresh.is_expired() && fresh.access_token != set.access_token {
+            return RefreshOutcome::Ok(fresh);
+        }
+    }
+    let Some(rt) = set.refresh_token.as_deref() else {
+        return RefreshOutcome::ReauthRequired("no refresh_token on file".into());
+    };
+    let client = match http_client() {
+        Ok(c) => c,
+        Err(e) => return RefreshOutcome::Transient(e.to_string()),
+    };
+    // Codex refresh path uses JSON body (observed in compatible clients).
+    let body = serde_json::json!({
+        "client_id": set.client_id.as_str(),
+        "grant_type": "refresh_token",
+        "refresh_token": rt,
+    });
+    let resp = match client
+        .post(TOKEN_URL)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return RefreshOutcome::Transient(format!("network: {e}")),
+    };
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        let lower = text.to_ascii_lowercase();
+        if status.as_u16() == 400
+            || lower.contains("invalid_grant")
+            || lower.contains("already")
+            || lower.contains("revoked")
+        {
+            clear_token();
+            return RefreshOutcome::ReauthRequired(format!(
+                "HTTP {status}: {}",
+                truncate(&text, 240)
+            ));
+        }
+        return RefreshOutcome::Transient(format!("HTTP {status}: {}", truncate(&text, 240)));
+    }
+    let v: serde_json::Value = match resp.json().await {
+        Ok(v) => v,
+        Err(e) => return RefreshOutcome::Transient(e.to_string()),
+    };
+    let access = match v.get("access_token").and_then(|x| x.as_str()) {
+        Some(a) => a.to_string(),
+        None => return RefreshOutcome::Transient("refresh response missing access_token".into()),
+    };
+    let refresh = v
+        .get("refresh_token")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| set.refresh_token.clone());
+    let id_token = v
+        .get("id_token")
+        .and_then(|x| x.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| set.id_token.clone());
+    let expires_in = v.get("expires_in").and_then(|x| x.as_u64());
+    let account_id = id_token
+        .as_deref()
+        .and_then(account_id_from_id_token)
+        .or_else(|| set.account_id.clone());
+    let label = id_token
+        .as_deref()
+        .and_then(label_from_id_token)
+        .or_else(|| set.label.clone());
+    let out = CodexTokenSet {
+        access_token: access,
+        refresh_token: refresh,
+        expires_at: expires_in.map(|s| now() + s as i64).or(set.expires_at),
+        id_token,
+        account_id,
+        client_id: set.client_id.clone(),
+        last_refresh_at: Some(now()),
+        scope: v
+            .get("scope")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| set.scope.clone()),
+        label,
+    };
+    if let Err(e) = save_token(&out) {
+        return RefreshOutcome::Transient(format!("save failed: {e}"));
+    }
+    RefreshOutcome::Ok(out)
+}
+
+/// Return a usable access token, refreshing if needed.
+pub async fn bearer_token() -> Result<(String, Option<String>)> {
+    if codex_disabled() {
+        bail!("Codex OAuth disabled via AIZEN_DISABLE_CODEX");
+    }
+    let mut set = load_token().context(
+        "no Codex login — run `aizen auth login codex` (experimental ChatGPT/Codex OAuth)",
+    )?;
+    if set.is_expired() {
+        match refresh_token(&set).await {
+            RefreshOutcome::Ok(s) => set = s,
+            RefreshOutcome::ReauthRequired(m) => {
+                bail!("Codex re-login required: {m} — run `aizen auth login codex`")
+            }
+            RefreshOutcome::Transient(m) => bail!("Codex token refresh failed: {m}"),
+        }
+    }
+    Ok((set.access_token, set.account_id))
+}
+
+/// True when this base_url should use the Codex Responses backend.
+pub fn is_codex_base_url(base_url: &str) -> bool {
+    let b = base_url.trim().trim_end_matches('/').to_ascii_lowercase();
+    if b == CODEX_BASE_URL
+        || b == CODEX_RESPONSES_URL
+            .trim_end_matches('/')
+            .to_ascii_lowercase()
+    {
+        return true;
+    }
+    // Host-matched: only first-party chatgpt.com Codex paths.
+    let after_scheme = b.split_once("://").map(|(_, r)| r).unwrap_or(b.as_str());
+    let host = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .split('@')
+        .next_back()
+        .unwrap_or("")
+        .split(':')
+        .next()
+        .unwrap_or("");
+    if host != "chatgpt.com" && !host.ends_with(".chatgpt.com") {
+        return false;
+    }
+    after_scheme.contains("/backend-api/codex")
+}
+
+/// Human status lines for `aizen auth status` (never prints raw tokens).
+pub fn status_lines() -> Vec<String> {
+    let mut lines = Vec::new();
+    if codex_disabled() {
+        lines.push("codex: disabled (AIZEN_DISABLE_CODEX)".into());
+        return lines;
+    }
+    match load_token() {
+        None => lines.push("codex: not logged in".into()),
+        Some(t) => {
+            let who = t.label.as_deref().unwrap_or("(no email claim)");
+            let exp = match t.expires_at {
+                Some(ts) => {
+                    let left = ts - now();
+                    if left <= 0 {
+                        "expired".into()
+                    } else if left > 3600 {
+                        format!("expires in {}h", left / 3600)
+                    } else {
+                        format!("expires in {}m", left / 60)
+                    }
+                }
+                None => "no expiry".into(),
+            };
+            let acct = t
+                .account_id
+                .as_deref()
+                .map(|a| format!("account {}", &a[..a.len().min(8)]))
+                .unwrap_or_else(|| "account ?".into());
+            let st = if t.is_expired() {
+                "needs refresh"
+            } else {
+                "ok"
+            };
+            lines.push(format!("codex: {st} · {who} · {acct}… · {exp}"));
+            lines.push(format!("  token file: {}", token_path().display()));
+        }
+    }
+    lines
+}
+
+pub fn risk_notice() -> &'static str {
+    "EXPERIMENTAL. Uses ChatGPT/Codex consumer OAuth and private backend APIs (not the OpenAI Platform API). May break without notice; may conflict with OpenAI terms; rate limits follow your ChatGPT/Codex plan. Prefer OpenAI API keys or OpenRouter for supported use. Remove tokens with: aizen auth logout codex"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authorize_url_encodes_scope_spaces_as_percent20() {
+        let u = build_authorize_url("http://127.0.0.1:1455/auth/callback", "st", "ch");
+        assert!(u.contains("scope=openid%20profile%20email%20offline_access"));
+        assert!(!u.contains("scope=openid+profile"));
+        assert!(u.contains("code_challenge_method=S256"));
+        assert!(u.contains("originator=codex_cli_rs"));
+        assert!(u.contains("client_id=app_EMoamEEZ73f0CkXaXp7hrann"));
+    }
+
+    #[test]
+    fn codex_base_url_detection() {
+        assert!(is_codex_base_url(CODEX_BASE_URL));
+        assert!(is_codex_base_url("https://chatgpt.com/backend-api/codex/"));
+        assert!(is_codex_base_url(CODEX_RESPONSES_URL));
+        assert!(!is_codex_base_url("https://api.openai.com/v1"));
+        assert!(!is_codex_base_url(
+            "https://evil.com/chatgpt.com/backend-api/codex"
+        ));
+    }
+
+    #[test]
+    fn account_id_from_synthetic_jwt() {
+        // header.payload.sig — payload {"chatgpt_account_id":"acc-123","email":"a@b.c"}
+        let payload = b64url(br#"{"chatgpt_account_id":"acc-123","email":"a@b.c"}"#);
+        let jwt = format!("x.{payload}.y");
+        assert_eq!(account_id_from_id_token(&jwt).as_deref(), Some("acc-123"));
+        assert_eq!(label_from_id_token(&jwt).as_deref(), Some("a@b.c"));
+    }
+}

--- a/src/llm/responses_codex.rs
+++ b/src/llm/responses_codex.rs
@@ -1,0 +1,687 @@
+//! ChatGPT Codex Responses API client (experimental).
+//!
+//! Maps Aizen's chat/tools types onto `POST …/codex/responses` SSE and back into [`ChatTurn`].
+//! Not the OpenAI Platform Responses API — field allowlists and headers follow the Codex CLI
+//! compatibility surface and may change without notice.
+
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use crate::core::types::{FunctionCall, Message, ToolCall, ToolDef, Usage};
+use crate::llm::client::ChatTurn;
+use crate::llm::codex_models;
+use crate::llm::oauth_codex::{self, CODEX_RESPONSES_URL};
+
+const ORIGINATOR: &str = "codex_cli_rs";
+const CODEX_UA: &str = "codex_cli_rs/0.136.0";
+const OVERLOAD_MARKERS: &[&str] = &["server_is_overloaded", "service_unavailable_error"];
+const CAPACITY_MARKERS: &[&str] = &["selected model is at capacity", "model_at_capacity"];
+
+const ALLOWLIST: &[&str] = &[
+    "model",
+    "input",
+    "instructions",
+    "tools",
+    "tool_choice",
+    "stream",
+    "store",
+    "reasoning",
+    "service_tier",
+    "include",
+    "prompt_cache_key",
+    "client_metadata",
+    "text",
+];
+
+/// Build Codex Responses JSON body from Aizen messages/tools.
+pub fn build_request_body(
+    model: &str,
+    messages: &[Message],
+    tools: &[ToolDef],
+    session_id: &str,
+    instructions: Option<&str>,
+) -> Value {
+    let (base_model, suffix_effort) = codex_models::strip_effort_suffix(model);
+    let mut input: Vec<Value> = Vec::new();
+    let mut sys_bits: Vec<String> = Vec::new();
+
+    for m in messages {
+        let role = m.role.as_str();
+        match role {
+            "system" => {
+                if let Some(c) = m.content.as_deref() {
+                    if !c.is_empty() {
+                        sys_bits.push(c.to_string());
+                    }
+                }
+            }
+            "tool" => {
+                let call_id = m.tool_call_id.clone().unwrap_or_default();
+                let text = m.content.clone().unwrap_or_default();
+                input.push(json!({
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": text,
+                }));
+            }
+            "assistant" if !m.tool_calls.is_empty() => {
+                if let Some(c) = m.content.as_deref() {
+                    if !c.is_empty() {
+                        input.push(message_item("assistant", c));
+                    }
+                }
+                for tc in &m.tool_calls {
+                    input.push(json!({
+                        "type": "function_call",
+                        "call_id": tc.id,
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    }));
+                }
+            }
+            "assistant" | "user" | "developer" => {
+                let role = if role == "assistant" {
+                    "assistant"
+                } else if role == "developer" {
+                    "developer"
+                } else {
+                    "user"
+                };
+                let text = m.content.clone().unwrap_or_default();
+                // Images: pass data URLs as input_image when present on user turns.
+                if role == "user" && !m.images.is_empty() {
+                    let mut content = Vec::new();
+                    if !text.is_empty() {
+                        content.push(json!({"type": "input_text", "text": text}));
+                    }
+                    for img in &m.images {
+                        content.push(
+                            json!({"type": "input_image", "image_url": img, "detail": "auto"}),
+                        );
+                    }
+                    input.push(json!({"type": "message", "role": "user", "content": content}));
+                } else if !text.is_empty() || role == "user" {
+                    input.push(message_item(role, &text));
+                }
+            }
+            _ => {
+                if let Some(c) = m.content.as_deref() {
+                    if !c.is_empty() {
+                        input.push(message_item("user", c));
+                    }
+                }
+            }
+        }
+    }
+
+    if input.is_empty() {
+        input.push(message_item("user", "..."));
+    }
+
+    let instr = if let Some(i) = instructions {
+        i.to_string()
+    } else if !sys_bits.is_empty() {
+        sys_bits.join("\n\n")
+    } else {
+        default_instructions().to_string()
+    };
+
+    // If we already folded system into instructions, also keep a developer message for cache
+    // locality when there were system bits — optional; instructions alone is enough for Codex.
+    let _ = sys_bits;
+
+    let mut body = json!({
+        "model": base_model,
+        "input": input,
+        "instructions": instr,
+        "stream": true,
+        "store": false,
+        "prompt_cache_key": session_id,
+    });
+
+    if !tools.is_empty() {
+        let mut codex_tools = Vec::new();
+        let mut names = BTreeSet::new();
+        for t in tools {
+            let name = t.function.name.trim();
+            if name.is_empty() {
+                continue;
+            }
+            names.insert(name.to_string());
+            let mut tool = json!({
+                "type": "function",
+                "name": name,
+                "parameters": t.function.parameters,
+            });
+            if !t.function.description.is_empty() {
+                tool["description"] = json!(t.function.description);
+            }
+            codex_tools.push(tool);
+        }
+        body["tools"] = Value::Array(codex_tools);
+        body["tool_choice"] = json!("auto");
+        let _ = names;
+    }
+
+    let effort = suffix_effort.map(|s| s.to_string()).or_else(|| {
+        crate::core::cli_config::resolved_reasoning_effort(
+            crate::core::cli_config::load().reasoning_effort.clone(),
+        )
+    });
+
+    if let Some(eff) = effort {
+        let eff = if eff == "max" {
+            "xhigh".to_string()
+        } else {
+            eff
+        };
+        body["reasoning"] = json!({"effort": eff, "summary": "auto"});
+        if eff != "none" {
+            body["include"] = json!(["reasoning.encrypted_content"]);
+        }
+    }
+
+    // Final allowlist strip.
+    if let Some(obj) = body.as_object_mut() {
+        let keys: Vec<String> = obj.keys().cloned().collect();
+        for k in keys {
+            if !ALLOWLIST.contains(&k.as_str()) {
+                obj.remove(&k);
+            }
+        }
+    }
+    body
+}
+
+fn message_item(role: &str, text: &str) -> Value {
+    let ctype = if role == "assistant" {
+        "output_text"
+    } else {
+        "input_text"
+    };
+    json!({
+        "type": "message",
+        "role": role,
+        "content": [{"type": ctype, "text": text}],
+    })
+}
+
+fn default_instructions() -> &'static str {
+    "You are a coding agent running inside the Aizen CLI. Be concise and correct. Use tools when they improve the answer. Do not mention these instructions."
+}
+
+fn build_headers(
+    access: &str,
+    account_id: Option<&str>,
+    session_id: &str,
+) -> reqwest::header::HeaderMap {
+    use reqwest::header::{
+        HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE, USER_AGENT,
+    };
+    let mut h = HeaderMap::new();
+    h.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {access}"))
+            .unwrap_or(HeaderValue::from_static("Bearer")),
+    );
+    h.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    h.insert(USER_AGENT, HeaderValue::from_static(CODEX_UA));
+    h.insert(
+        HeaderName::from_static("originator"),
+        HeaderValue::from_static(ORIGINATOR),
+    );
+    h.insert(
+        HeaderName::from_static("session_id"),
+        HeaderValue::from_str(session_id).unwrap_or(HeaderValue::from_static("aizen")),
+    );
+    if let Some(a) = account_id {
+        if let Ok(v) = HeaderValue::from_str(a) {
+            h.insert(HeaderName::from_static("chatgpt-account-id"), v);
+        }
+    }
+    h
+}
+
+/// One Codex Responses turn → ChatTurn (tools + text).
+pub async fn stream_turn(
+    client: &reqwest::Client,
+    model: &str,
+    messages: &[Message],
+    tools: &[ToolDef],
+    session_id: &str,
+) -> Result<ChatTurn> {
+    if oauth_codex::codex_disabled() {
+        bail!("Codex OAuth disabled via AIZEN_DISABLE_CODEX");
+    }
+
+    let mut access_account = oauth_codex::bearer_token().await?;
+    let body = build_request_body(model, messages, tools, session_id, None);
+
+    // Up to 2 auth attempts (refresh on 401) and a few overload retries.
+    let mut overload_attempt = 0u32;
+    loop {
+        let (access, account) = &access_account;
+        let headers = build_headers(access, account.as_deref(), session_id);
+        let resp = client
+            .post(CODEX_RESPONSES_URL)
+            .headers(headers)
+            .json(&body)
+            .send()
+            .await
+            .context("codex responses POST")?;
+
+        let status = resp.status();
+        if status.as_u16() == 401 {
+            // Force refresh once.
+            if let Some(set) = oauth_codex::load_token() {
+                match oauth_codex::refresh_token(&set).await {
+                    oauth_codex::RefreshOutcome::Ok(s) => {
+                        access_account = (s.access_token, s.account_id);
+                        continue;
+                    }
+                    oauth_codex::RefreshOutcome::ReauthRequired(m) => {
+                        bail!("Codex auth failed (re-login): {m}");
+                    }
+                    oauth_codex::RefreshOutcome::Transient(m) => {
+                        bail!("Codex auth failed: {m}");
+                    }
+                }
+            }
+            bail!("Codex HTTP 401 — run `aizen auth login codex`");
+        }
+        if status.as_u16() == 429 {
+            let text = resp.text().await.unwrap_or_default();
+            if let Some(msg) = parse_usage_limit(&text) {
+                bail!("{msg}");
+            }
+            bail!("Codex rate limited (HTTP 429): {}", truncate(&text, 300));
+        }
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            bail!("Codex HTTP {status}: {}", truncate(&text, 500));
+        }
+
+        // Read SSE body fully (Codex forces stream). For v1 we buffer the stream; blank-stream
+        // retry at higher layer can still re-call stream_turn.
+        let bytes = resp.bytes().await.context("reading codex SSE body")?;
+        let text = String::from_utf8_lossy(&bytes);
+        let lower = text.to_ascii_lowercase();
+
+        if CAPACITY_MARKERS.iter().any(|m| lower.contains(m)) {
+            bail!("Selected model is at capacity. Try a different Codex model.");
+        }
+        if OVERLOAD_MARKERS.iter().any(|m| lower.contains(m)) {
+            if overload_attempt >= 3 {
+                bail!("Codex upstream overloaded — retries exhausted");
+            }
+            overload_attempt += 1;
+            tokio::time::sleep(Duration::from_secs(
+                2u64.saturating_mul(overload_attempt as u64),
+            ))
+            .await;
+            continue;
+        }
+
+        return parse_sse_to_chat_turn(&text);
+    }
+}
+
+fn parse_usage_limit(text: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(text).ok()?;
+    let err = v.get("error")?;
+    if err.get("type").and_then(|t| t.as_str()) != Some("usage_limit_reached") {
+        return None;
+    }
+    let msg = err
+        .get("message")
+        .and_then(|m| m.as_str())
+        .unwrap_or("Codex usage limit reached");
+    if let Some(ts) = err.get("resets_at").and_then(|x| x.as_i64()) {
+        return Some(format!("{msg} (resets_at={ts})"));
+    }
+    if let Some(s) = err.get("resets_in_seconds").and_then(|x| x.as_u64()) {
+        return Some(format!("{msg} (resets in {s}s)"));
+    }
+    Some(msg.to_string())
+}
+
+/// Parse Codex Responses SSE into a ChatTurn.
+pub fn parse_sse_to_chat_turn(sse: &str) -> Result<ChatTurn> {
+    let mut text_out = String::new();
+    // call_id -> (name, arguments)
+    let mut tools: std::collections::BTreeMap<String, (String, String)> =
+        std::collections::BTreeMap::new();
+    let mut finish: Option<String> = None;
+    let mut usage: Option<Usage> = None;
+    let mut err_msg: Option<String> = None;
+
+    for raw_line in sse.lines() {
+        let line = raw_line.trim_end();
+        if !line.starts_with("data:") {
+            continue;
+        }
+        let data = line.trim_start_matches("data:").trim();
+        if data.is_empty() || data == "[DONE]" {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(data) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        // Nested error objects
+        if let Some(msg) = nested_error_message(&v) {
+            err_msg = Some(msg);
+        }
+
+        let ty = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        match ty {
+            "response.output_text.delta" => {
+                if let Some(d) = v.get("delta").and_then(|d| d.as_str()) {
+                    text_out.push_str(d);
+                } else if let Some(d) = v.pointer("/delta/text").and_then(|d| d.as_str()) {
+                    text_out.push_str(d);
+                }
+            }
+            "response.output_text.done" => {
+                if let Some(t) = v.get("text").and_then(|t| t.as_str()) {
+                    if text_out.is_empty() {
+                        text_out.push_str(t);
+                    }
+                }
+            }
+            "response.function_call_arguments.delta" => {
+                let id = v
+                    .get("call_id")
+                    .or_else(|| v.get("item_id"))
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("call")
+                    .to_string();
+                let name = v
+                    .get("name")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let delta = v.get("delta").and_then(|x| x.as_str()).unwrap_or("");
+                let e = tools
+                    .entry(id)
+                    .or_insert_with(|| (name.clone(), String::new()));
+                if e.0.is_empty() && !name.is_empty() {
+                    e.0 = name;
+                }
+                e.1.push_str(delta);
+            }
+            "response.function_call_arguments.done" | "response.output_item.done" => {
+                // Full item may carry name/arguments/call_id
+                if let Some(item) = v.get("item") {
+                    ingest_output_item(item, &mut tools, &mut text_out);
+                }
+                if ty == "response.function_call_arguments.done" {
+                    let id = v
+                        .get("call_id")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("call")
+                        .to_string();
+                    let name = v
+                        .get("name")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let args = v
+                        .get("arguments")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if !args.is_empty() || !name.is_empty() {
+                        let e = tools
+                            .entry(id)
+                            .or_insert_with(|| (name.clone(), String::new()));
+                        if e.0.is_empty() {
+                            e.0 = name;
+                        }
+                        if e.1.is_empty() {
+                            e.1 = args;
+                        }
+                    }
+                }
+            }
+            "response.output_item.added" => {
+                if let Some(item) = v.get("item") {
+                    ingest_output_item(item, &mut tools, &mut text_out);
+                }
+            }
+            "response.completed" => {
+                finish = Some("stop".into());
+                if let Some(u) = v.pointer("/response/usage") {
+                    usage = parse_usage(u);
+                } else if let Some(u) = v.get("usage") {
+                    usage = parse_usage(u);
+                }
+                if let Some(out) = v.pointer("/response/output") {
+                    if let Some(arr) = out.as_array() {
+                        for item in arr {
+                            ingest_output_item(item, &mut tools, &mut text_out);
+                        }
+                    }
+                }
+            }
+            "response.failed" | "error" => {
+                if let Some(msg) = nested_error_message(&v) {
+                    err_msg = Some(msg);
+                } else {
+                    err_msg = Some(format!("codex {ty}"));
+                }
+            }
+            _ => {
+                // Some gateways put output text under response.output without type prefixing every delta.
+                if let Some(out) = v.pointer("/response/output") {
+                    if let Some(arr) = out.as_array() {
+                        for item in arr {
+                            ingest_output_item(item, &mut tools, &mut text_out);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(e) = err_msg {
+        if text_out.is_empty() && tools.is_empty() {
+            bail!("Codex error: {e}");
+        }
+    }
+
+    let tool_calls: Vec<ToolCall> = tools
+        .into_iter()
+        .map(|(id, (name, arguments))| ToolCall {
+            id,
+            kind: "function".into(),
+            function: FunctionCall {
+                name,
+                arguments: if arguments.is_empty() {
+                    "{}".into()
+                } else {
+                    arguments
+                },
+            },
+        })
+        .collect();
+
+    if !tool_calls.is_empty() {
+        finish = Some("tool_calls".into());
+    }
+
+    Ok(ChatTurn {
+        content: if text_out.is_empty() {
+            None
+        } else {
+            Some(text_out)
+        },
+        tool_calls,
+        finish_reason: finish,
+        usage,
+        eager: Default::default(),
+    })
+}
+
+fn ingest_output_item(
+    item: &Value,
+    tools: &mut std::collections::BTreeMap<String, (String, String)>,
+    text_out: &mut String,
+) {
+    let ty = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    match ty {
+        "message" => {
+            if let Some(content) = item.get("content").and_then(|c| c.as_array()) {
+                for part in content {
+                    let pt = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    if pt == "output_text" || pt == "text" {
+                        if let Some(t) = part.get("text").and_then(|t| t.as_str()) {
+                            if text_out.is_empty() {
+                                text_out.push_str(t);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        "function_call" => {
+            let id = item
+                .get("call_id")
+                .or_else(|| item.get("id"))
+                .and_then(|x| x.as_str())
+                .unwrap_or("call")
+                .to_string();
+            let name = item
+                .get("name")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+            let args = item
+                .get("arguments")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+            let e = tools
+                .entry(id)
+                .or_insert_with(|| (name.clone(), String::new()));
+            if e.0.is_empty() {
+                e.0 = name;
+            }
+            if e.1.is_empty() {
+                e.1 = args;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_usage(u: &Value) -> Option<Usage> {
+    let mut usage = Usage::default();
+    usage.prompt_tokens = u
+        .get("input_tokens")
+        .or_else(|| u.get("prompt_tokens"))
+        .and_then(|x| x.as_u64());
+    usage.completion_tokens = u
+        .get("output_tokens")
+        .or_else(|| u.get("completion_tokens"))
+        .and_then(|x| x.as_u64());
+    usage.total_tokens = u.get("total_tokens").and_then(|x| x.as_u64());
+    usage.cache_read_input_tokens = u.get("cache_read_input_tokens").and_then(|x| x.as_u64());
+    Some(usage)
+}
+
+fn nested_error_message(v: &Value) -> Option<String> {
+    if let Some(m) = v.pointer("/error/message").and_then(|m| m.as_str()) {
+        return Some(m.to_string());
+    }
+    if let Some(m) = v.get("message").and_then(|m| m.as_str()) {
+        if v.get("type").and_then(|t| t.as_str()) == Some("error") {
+            return Some(m.to_string());
+        }
+    }
+    None
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        let t: String = s.chars().take(n).collect();
+        format!("{t}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::types::{FunctionDef, ToolDef};
+
+    #[test]
+    fn build_body_maps_tools_and_strips_disallowed() {
+        let msgs = vec![Message::user("hi")];
+        let tools = vec![ToolDef {
+            kind: "function".into(),
+            function: FunctionDef {
+                name: "read_file".into(),
+                description: "read".into(),
+                parameters: json!({"type":"object","properties":{}}),
+            },
+            cache_control: None,
+        }];
+        let body = build_request_body("gpt-5.4-mini-high", &msgs, &tools, "sess", None);
+        assert_eq!(body["model"], "gpt-5.4-mini");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
+        assert!(body.get("temperature").is_none());
+        assert!(body.get("max_tokens").is_none());
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert!(body["tools"].as_array().unwrap().len() == 1);
+        assert_eq!(body["tools"][0]["name"], "read_file");
+        assert_eq!(body["prompt_cache_key"], "sess");
+    }
+
+    #[test]
+    fn parse_text_delta_sse() {
+        let sse = "\
+event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hel\"}\n\n\
+event: response.output_text.delta\n\
+data: {\"type\":\"response.output_text.delta\",\"delta\":\"lo\"}\n\n\
+event: response.completed\n\
+data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":2}}}\n\n\
+";
+        let turn = parse_sse_to_chat_turn(sse).unwrap();
+        assert_eq!(turn.content.as_deref(), Some("Hello"));
+        assert!(turn.tool_calls.is_empty());
+        assert_eq!(turn.usage.unwrap().prompt_tokens, Some(3));
+    }
+
+    #[test]
+    fn parse_function_call_sse() {
+        let sse = r#"
+data: {"type":"response.function_call_arguments.delta","call_id":"c1","name":"shell","delta":"{\"cmd\":"}
+data: {"type":"response.function_call_arguments.delta","call_id":"c1","delta":"\"ls\"}"}
+data: {"type":"response.function_call_arguments.done","call_id":"c1","name":"shell","arguments":"{\"cmd\":\"ls\"}"}
+data: {"type":"response.completed","response":{"output":[]}}
+"#;
+        let turn = parse_sse_to_chat_turn(sse).unwrap();
+        assert_eq!(turn.tool_calls.len(), 1);
+        assert_eq!(turn.tool_calls[0].function.name, "shell");
+        assert!(turn.tool_calls[0].function.arguments.contains("ls"));
+    }
+
+    #[test]
+    fn system_becomes_instructions() {
+        let msgs = vec![Message::system("be brief"), Message::user("hi")];
+        let body = build_request_body("gpt-5.4", &msgs, &[], "s", None);
+        assert_eq!(body["instructions"], "be brief");
+        let input = body["input"].as_array().unwrap();
+        assert!(input
+            .iter()
+            .all(|i| i.get("role").and_then(|r| r.as_str()) != Some("system")));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,11 @@ enum Commands {
         #[command(subcommand)]
         cmd: Option<ConfigCmd>,
     },
+    /// Provider sign-in (experimental). Currently: ChatGPT Codex OAuth.
+    Auth {
+        #[command(subcommand)]
+        cmd: AuthCmd,
+    },
     /// List the models the provider advertises (GET {base}/models).
     Models(ModelsArgs),
     /// Crawl a website (katana-style): BFS over HTTP, extract links from HTML + endpoints from JS.
@@ -708,6 +713,20 @@ struct CrawlArgs {
     show_source: bool,
 }
 
+/// `aizen auth …` — experimental provider OAuth (ChatGPT Codex).
+#[derive(Subcommand, Debug)]
+enum AuthCmd {
+    /// Browser PKCE login for ChatGPT Codex (experimental / ToS risk).
+    Login {
+        /// Provider id. Only `codex` is supported today.
+        provider: String,
+    },
+    /// Show login state (never prints raw tokens).
+    Status,
+    /// Delete cached tokens for a provider.
+    Logout { provider: String },
+}
+
 #[derive(Subcommand, Debug)]
 enum ConfigCmd {
     /// Set one or more config fields (only the flags you pass are changed).
@@ -1256,6 +1275,7 @@ async fn main() -> Result<()> {
             BenchCmd::Loop => bench::loop_eval::run().await,
         },
         Commands::Config { cmd } => run_config(cmd).await,
+        Commands::Auth { cmd } => run_auth(cmd).await,
         Commands::Models(args) => run_models(args).await,
         Commands::Crawl(args) => run_crawl(args).await,
         Commands::Reach { cmd } => run_reach(cmd).await,
@@ -11552,6 +11572,53 @@ fn apply_role_flags(
     *slot = (rc.model.is_some() || rc.base_url.is_some() || rc.api_key_ref.is_some()).then_some(rc);
 }
 
+async fn run_auth(cmd: AuthCmd) -> Result<()> {
+    match cmd {
+        AuthCmd::Login { provider } => {
+            let p = provider.trim().to_ascii_lowercase();
+            if p != "codex" && p != "chatgpt" && p != "chatgpt-codex" {
+                anyhow::bail!(
+                    "unknown auth provider '{provider}' — supported: codex (ChatGPT Codex OAuth, experimental)"
+                );
+            }
+            if crate::llm::oauth_codex::codex_disabled() {
+                anyhow::bail!("Codex OAuth disabled via AIZEN_DISABLE_CODEX");
+            }
+            println!("{}", crate::llm::oauth_codex::risk_notice());
+            println!();
+            let set = crate::llm::oauth_codex::login_interactive().await?;
+            let who = set.label.as_deref().unwrap_or("(signed in)");
+            println!("✓ Codex login saved for {who}");
+            println!(
+                "  token file: {}",
+                crate::llm::oauth_codex::token_path().display()
+            );
+            println!("  next: aizen config  → pick 'ChatGPT Codex (experimental)' or:");
+            println!(
+                "        aizen config set --base-url {} --api-key codex-oauth --model {}",
+                crate::llm::oauth_codex::CODEX_BASE_URL,
+                crate::llm::codex_models::default_model()
+            );
+            Ok(())
+        }
+        AuthCmd::Status => {
+            for line in crate::llm::oauth_codex::status_lines() {
+                println!("{line}");
+            }
+            Ok(())
+        }
+        AuthCmd::Logout { provider } => {
+            let p = provider.trim().to_ascii_lowercase();
+            if p != "codex" && p != "chatgpt" && p != "chatgpt-codex" {
+                anyhow::bail!("unknown auth provider '{provider}' — supported: codex");
+            }
+            crate::llm::oauth_codex::clear_token();
+            println!("✓ Codex tokens removed");
+            Ok(())
+        }
+    }
+}
+
 async fn run_config(cmd: Option<ConfigCmd>) -> Result<()> {
     let cmd = match cmd {
         Some(c) => c,
@@ -12444,6 +12511,12 @@ const PROVIDER_PRESETS: &[ProviderPreset] = &[
         base: "https://api.openai.com/v1",
         keys_url: "https://platform.openai.com/api-keys",
         sample_model: "gpt-4o",
+    },
+    ProviderPreset {
+        label: "ChatGPT Codex (experimental)",
+        base: crate::llm::oauth_codex::CODEX_BASE_URL,
+        keys_url: "run: aizen auth login codex  (experimental ChatGPT OAuth — see docs RISK)",
+        sample_model: "gpt-5.4-mini",
     },
     ProviderPreset {
         label: "Anthropic (Claude)",
@@ -14591,6 +14664,23 @@ async fn config_setup_full(cfg: &mut cli_config::CliConfig) -> Result<()> {
 
 async fn run_models(args: ModelsArgs) -> Result<()> {
     let (base_url, api_key) = resolve_base_key(args.base_url, args.api_key)?;
+    // Codex has no stable OpenAI-style /models; print the curated experimental catalog.
+    if crate::llm::oauth_codex::is_codex_base_url(&base_url) {
+        let current = cli_config::load().model;
+        println!("ChatGPT Codex models (experimental catalog):");
+        for (id, label) in crate::llm::codex_models::CODEX_MODELS {
+            let mark = if current.as_deref() == Some(*id) {
+                " (default)"
+            } else {
+                ""
+            };
+            println!("{id}  · {label}  · codex{mark}");
+        }
+        if !crate::llm::oauth_codex::has_token() {
+            println!("(not logged in — run: aizen auth login codex)");
+        }
+        return Ok(());
+    }
     let http = http_client()?;
     let infos = client::fetch_models_info(&http, &base_url, &api_key)
         .await
@@ -16208,6 +16298,7 @@ mod tests {
     }
 
     #[test]
+    #[test]
     fn opencode_free_preset_is_registered() {
         let p = PROVIDER_PRESETS
             .iter()
@@ -16222,6 +16313,15 @@ mod tests {
             "the sample must be a free-tier id, got {}",
             p.sample_model
         );
+    #[test]
+    fn codex_experimental_preset_is_registered() {
+        let p = PROVIDER_PRESETS
+            .iter()
+            .find(|p| p.label == "ChatGPT Codex (experimental)")
+            .expect("codex preset");
+        assert_eq!(p.base, crate::llm::oauth_codex::CODEX_BASE_URL);
+        assert!(p.keys_url.contains("auth login codex"));
+        assert!(!p.sample_model.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16298,7 +16298,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn opencode_free_preset_is_registered() {
         let p = PROVIDER_PRESETS
             .iter()
@@ -16313,6 +16312,8 @@ mod tests {
             "the sample must be a free-tier id, got {}",
             p.sample_model
         );
+    }
+
     #[test]
     fn codex_experimental_preset_is_registered() {
         let p = PROVIDER_PRESETS


### PR DESCRIPTION
## What

Experimental **ChatGPT Codex** provider integrated **directly in Aizen** (no external router):

- `aizen auth login|status|logout codex` — browser PKCE
- Preset **ChatGPT Codex (experimental)** → Codex Responses backend
- Tool/SSE mapping into existing `ChatTurn` loop
- Kill-switch: `AIZEN_DISABLE_CODEX=1`

## Risk

Consumer OAuth + private backend APIs (not Platform API). May break / ToS risk.

## Tests

- cargo fmt --check
- unit tests oauth/SSE/preset
