### PR TITLE
fix(auth): make ChatGPT Codex OAuth login work on Windows

### DIFF
--- a/src/llm/oauth_codex.rs
+++ b/src/llm/oauth_codex.rs
@@ -165,9 +165,12 @@ fn pkce() -> Result<(String, String)> {
 }
 
 fn open_browser(url: &str) {
+    // Do not route the URL through `cmd /C start`: OAuth query strings contain `&`,
+    // which cmd treats as command separators. Use Windows URL protocol handling directly,
+    // so the complete authorize URL is handed to the default browser as one argument.
     #[cfg(target_os = "windows")]
-    let _ = std::process::Command::new("cmd")
-        .args(["/C", "start", "", url])
+    let _ = std::process::Command::new("rundll32.exe")
+        .args(["url.dll,FileProtocolHandler", url])
         .spawn();
     #[cfg(target_os = "macos")]
     let _ = std::process::Command::new("open").arg(url).spawn();
@@ -316,17 +319,13 @@ async fn respond(sock: &mut tokio::net::TcpStream, message: &str) {
     let _ = sock.flush().await;
 }
 
-async fn bind_callback_listener() -> Result<(tokio::net::TcpListener, u16, bool)> {
-    match tokio::net::TcpListener::bind(("127.0.0.1", PREFERRED_CALLBACK_PORT)).await {
-        Ok(l) => Ok((l, PREFERRED_CALLBACK_PORT, false)),
-        Err(_) => {
-            let l = tokio::net::TcpListener::bind("127.0.0.1:0")
-                .await
-                .context("binding loopback callback port")?;
-            let port = l.local_addr()?.port();
-            Ok((l, port, true))
-        }
-    }
+async fn bind_callback_listener() -> Result<tokio::net::TcpListener> {
+    tokio::net::TcpListener::bind(("127.0.0.1", PREFERRED_CALLBACK_PORT))
+        .await
+        .with_context(|| format!(
+            "binding Codex OAuth callback at http://localhost:{PREFERRED_CALLBACK_PORT}/auth/callback; \
+             ensure port {PREFERRED_CALLBACK_PORT} is free and retry"
+        ))
 }
 
 /// Interactive browser login. Returns the saved token set.
@@ -334,13 +333,10 @@ pub async fn login_interactive() -> Result<CodexTokenSet> {
     if codex_disabled() {
         bail!("Codex OAuth disabled via AIZEN_DISABLE_CODEX");
     }
-    let (listener, port, fallback) = bind_callback_listener().await?;
-    if fallback {
-        eprintln!(
-            "note: port {PREFERRED_CALLBACK_PORT} busy — using ephemeral :{port}. If OpenAI rejects the redirect, free {PREFERRED_CALLBACK_PORT} (other Codex CLI) and retry."
-        );
-    }
-    let redirect_uri = format!("http://127.0.0.1:{port}/auth/callback");
+    // Codex registers one fixed callback URI; using an ephemeral fallback port makes
+    // OpenAI reject the authorize request before login with `invalid_authorize_request`.
+    let listener = bind_callback_listener().await?;
+    let redirect_uri = format!("http://localhost:{PREFERRED_CALLBACK_PORT}/auth/callback");
     let (verifier, challenge) = pkce()?;
     let state = rand_b64url(16)?;
     let auth_url = build_authorize_url(&redirect_uri, &state, &challenge);
@@ -710,7 +706,7 @@ mod tests {
 
     #[test]
     fn authorize_url_encodes_scope_spaces_as_percent20() {
-        let u = build_authorize_url("http://127.0.0.1:1455/auth/callback", "st", "ch");
+        let u = build_authorize_url("http://localhost:1455/auth/callback", "st", "ch");
         assert!(u.contains("scope=openid%20profile%20email%20offline_access"));
         assert!(!u.contains("scope=openid+profile"));
         assert!(u.contains("code_challenge_method=S256"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -11171,6 +11171,10 @@ fn resolve_endpoint(
     Ok((base_url, api_key, model))
 }
 
+fn codex_oauth_api_key(base_url: &str) -> Option<String> {
+    crate::llm::oauth_codex::is_codex_base_url(base_url).then(|| "codex-oauth".to_string())
+}
+
 fn resolve_base_key(base_url: Option<String>, api_key: Option<String>) -> Result<(String, String)> {
     let cfg = cli_config::load();
     let base_url = base_url
@@ -11180,6 +11184,7 @@ fn resolve_base_key(base_url: Option<String>, api_key: Option<String>) -> Result
     let api_key = api_key
         .or_else(|| cli_config::branded_env("API_KEY"))
         .or(cfg.api_key)
+        .or_else(|| codex_oauth_api_key(&base_url))
         .context("no API key — run `aizen config`")?;
     Ok((base_url, api_key))
 }
@@ -12735,6 +12740,22 @@ async fn prompt_validated_api_key(
     current: Option<&str>,
     keys_url: Option<&str>,
 ) -> Result<Option<(String, Vec<client::ModelInfo>)>> {
+    if crate::llm::oauth_codex::is_codex_base_url(base) {
+        let infos = crate::llm::codex_models::CODEX_MODELS
+            .iter()
+            .map(|(id, _label)| client::ModelInfo {
+                id: (*id).to_string(),
+                context_length: None,
+                is_free: false,
+            })
+            .collect();
+        if crate::llm::oauth_codex::has_token() {
+            line_ok("using saved ChatGPT/Codex login tokens");
+        } else {
+            line_warn("no Codex login found yet — run `aizen auth login codex` before using this provider");
+        }
+        return Ok(Some(("codex-oauth".to_string(), infos)));
+    }
     if let Some(url) = keys_url {
         tui::emit_line(&format!("  {}", style(format!("get a key: {url}")).dim()));
     }
@@ -16312,6 +16333,15 @@ mod tests {
             "the sample must be a free-tier id, got {}",
             p.sample_model
         );
+    }
+
+    #[test]
+    fn codex_base_uses_oauth_placeholder_without_api_key() {
+        assert_eq!(
+            codex_oauth_api_key(crate::llm::oauth_codex::CODEX_BASE_URL).as_deref(),
+            Some("codex-oauth")
+        );
+        assert_eq!(codex_oauth_api_key("https://api.openai.com/v1"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix Windows ChatGPT/Codex OAuth login so the authorize URL is opened intact via `rundll32 url.dll,FileProtocolHandler` instead of `cmd /C start` (which split on `&`).
- Use the registered Codex callback exactly: `http://localhost:1455/auth/callback`.
- Refuse ephemeral fallback ports (they make OpenAI return `invalid_authorize_request`).
- Treat Codex base URLs as OAuth in config/setup so users are not forced through normal API-key verification.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check --bin aizen`
- [x] `cargo test --bin aizen oauth_codex`
- [x] Live Windows login: browser completed and `aizen auth status` reported `codex: ok`
- [x] CI green on this PR