### PR TITLE
ci(cla): fail with the real cause when the signature branch is missing

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,6 +8,9 @@ name: cla
 # A contributor agrees by commenting the exact sentence on their PR:
 #     I have read the CLA Document and I hereby sign the CLA
 #
+# PREREQUISITE: the `cla-signatures` branch must exist and must NOT be protected. The action writes
+# the ledger there but never creates the branch — see the preflight step below for what breaks.
+#
 # This replaced the DCO sign-off check: the CLA covers authorship certification AND the broader
 # relicensing grant in CLA.md §3, so asking for both would put contributors through two gates for
 # overlapping reasons. The allowlist holds bots and the maintainer only — human contributors are not
@@ -34,6 +37,22 @@ jobs:
          contains(github.event.comment.body, 'recheck'))) ||
       github.event_name == 'pull_request_target'
     steps:
+      # The action stores signatures on `cla-signatures` but cannot create that branch: its
+      # persistence layer calls `repos.createOrUpdateFileContents({branch: 'cla-signatures'})`, which
+      # 404s when the branch is absent. It swallows that error, then ends the run with
+      # "Committers of pull request N have to sign the CLA" — blaming the contributor for a repo
+      # misconfiguration, on every PR, no matter who signed. Fail first, and say what is really wrong.
+      - name: Signature storage branch must exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${GITHUB_REPOSITORY}/branches/cla-signatures" >/dev/null 2>&1; then
+            echo "cla-signatures is present."
+            exit 0
+          fi
+          echo "::error::Branch 'cla-signatures' is missing from ${GITHUB_REPOSITORY}. The CLA bot stores signatures there and cannot create it itself, so this check fails for everyone regardless of who signed. Recreate it as an orphan branch containing cla/signatures.json with {\"signedContributors\": []}, and leave it unprotected."
+          exit 1
+
       - name: CLA assistant
         uses: contributor-assistant/github-action@v2.6.1
         env:


### PR DESCRIPTION
## What does this PR do?

Makes the `cla` check report the actual problem when its storage branch is missing, instead of blaming the contributor.

## The bug this came out of

`contributor-assistant/github-action` keeps the signature ledger in `cla/signatures.json` on the `cla-signatures` branch, but **it never creates that branch**. [`persistence.ts::createFile`](https://github.com/contributor-assistant/github-action/blob/v2.6.1/src/persistence/persistence.ts) calls `repos.createOrUpdateFileContents({branch: 'cla-signatures'})`, which 404s when the branch is absent.

[`setupClaCheck.ts`](https://github.com/contributor-assistant/github-action/blob/v2.6.1/src/setupClaCheck.ts) catches that into `core.setFailed`, **keeps going**, and then ends with:

```
Committers of pull request N have to sign the CLA
```

So the headline annotation pointed at the contributor, while the real cause sat in a second annotation nobody reads first:

```
Error occurred when creating the signed contributors file: Branch cla-signatures not found.
```

`cla.yml` has pointed at `cla-signatures` since a4fe1f6 and the branch was never created — so the check was red on **100% of runs**, on every PR, no matter who signed. #13 is where it surfaced: its author posted the exact sign sentence, the bot even commented "All contributors have signed the CLA ✅", and the check stayed red anyway.

The branch now exists and #13 went green, so this is not a live outage — it is a guard so the next person is not sent chasing their own signature.

## Type of change

- [x] Bug fix (regression test included) — CI config; behaviour verified on the live `cla` run rather than by a unit test
- [ ] New feature (discussed in an issue first)
- [x] Docs / comments / tests only
- [ ] Refactor (no behavior change)

## Checklist

- [x] I ran `cargo test --bin aizen` and it's **green**. — n/a, no Rust touched
- [x] I ran `cargo fmt` and `cargo clippy` and cleared anything I introduced. — n/a, no Rust touched
- [x] I added or updated tests for my change. — n/a, workflow-only
- [x] My change keeps the **pure-Rust single-static-binary** posture (no new C/native deps).
- [x] I have agreed to the [CLA](../blob/main/CLA.md).

## Notes for the reviewer

- The preflight is a read-only `gh api .../branches/cla-signatures` using the built-in `GITHUB_TOKEN`; `contents: read` is already covered by the job's `contents: write`.
- It runs on both triggers (`issue_comment` and `pull_request_target`) and costs one API call.
- The action pin stays at `v2.6.1` — that **is** the latest release (2024-09-26), so the Node 20 deprecation warning cannot be cleared by bumping.
- `cla-signatures` is an orphan branch, shares no history with `main`, and carries a README saying not to delete or protect it.