### PR TITLE
Reach the settings and run knobs from the CLI; unbreak the gnu link; skills/effort fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ development log lives in that monorepo's history.
   flag keeps the old behaviour exactly — the configured `reasoning_effort` applies and the request
   stays byte-identical to one from a core that never had the flag. The tier is named on stderr.
 
+### Fixed
+- **`/effort`'s top stop did the opposite of its label.** The rail draws seven stops and `ultimate`
+  is the seventh, but `apply_effort_choice` only handled `1..=5`; index 6 fell through to the
+  catch-all, so dragging all the way right and pressing Enter turned auto-detect **on** and cleared
+  the pin — never setting `ultimate` at all. `effort_slider_start` could not return 6 either, so
+  the slider could not open on the mode even once it was on. Both fixed, and every branch now
+  writes `ultimate`: sliding down off the top stop has to turn the mode off, or the rung just
+  chosen is silently overruled each turn by a flag nothing cleared. The input box is recoloured on
+  commit, exactly as `/ultimate` does it.
+
 ## [0.6.5] — 2026-08-17
 
 An OS-level sandbox underneath the approval layer, and an honest per-platform account of what it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ development log lives in that monorepo's history.
 
 ## [Unreleased]
 
+### Added
+- **`aizen config set` reaches the twelve keys it could not.** `update_check`, `skill_registry`,
+  `max_tokens`, `prompt_cache`, `prompt_tier`, `eager_tools`, `self_review`,
+  `max_parallel_subagents`, `workflow_tool`, `embed_model`, `timemachine_keep_safety` and
+  `sandbox.mode` are all read on every run and were settable by nothing: the interactive wizard
+  does not cover them, so the only way to change one was to hand-edit `cli-config.json` — around
+  the exclusive lock and the corrupt-file backup that `save` exists to provide. Each is now a flag,
+  and each can be put back: `--max-tokens 0` and `--max-subagents 0` return to the provider default
+  and the machine-derived band, an empty value clears `--prompt-tier` / `--skill-registry` /
+  `--embed-model`, and `--prompt-cache auto` restores the by-model-id decision — which is why that
+  one takes `auto|true|false` rather than a bool that could set the field but never unset it.
+  `--sandbox-mode` is named apart from the global `--sandbox` on purpose: that one overrides a
+  single invocation, this one is written down. The "nothing to set" guard became a list rather than
+  a thirty-term `&&` chain, since a flag added to the enum and forgotten in that chain would have
+  made `config set --that-flag` bail while quietly doing nothing.
+- **`aizen config set --{subagent,summarizer,oracle,apply}-provider`.** `RoleModelConfig.provider`
+  documents itself as the way to route a role — point it at a saved profile and the role inherits
+  that endpoint, its key and its default model, instead of repeating them field by field. It was
+  the one field of the four with no flag, so the "preferred" path was the only one you could not
+  take without hand-editing JSON, and `--<role>-base-url` + `--<role>-api-key-ref`, which the
+  struct itself calls legacy, were what a caller was pushed toward. An unknown profile name is
+  refused against `providers[]` rather than written, since a role routed to a profile that does not
+  exist surfaces as a failed run much later and nowhere near the typo. Empty clears, as with the
+  rest of the role fields — and the "is this role still configured?" test now counts `provider` and
+  `reasoning_effort` too, so clearing a role's model no longer silently drops a per-role effort set
+  by hand beside it.
+- **`aizen agent --save-session`.** The non-interactive loop could not leave a transcript behind:
+  autosave lives in the REPL's turn, so every one-shot run — and every run driven by a front-end
+  that shells out to `aizen agent` — vanished when the process exited. The flag writes the finished
+  conversation through the same `save_session` the REPL uses, so the file carries the same
+  provenance (project key, root, slug) and `/sessions` reopens it with no idea which surface
+  produced it. Off by default, because this subcommand is also the scripting and CI entry point and
+  a file per invocation would bury the pool the picker reads. The path is reported on stderr so
+  stdout stays the answer, and a run that ended in an error is saved too — it still happened.
+- **`aizen agent --effort auto|low|medium|high|xhigh|max`.** Reasoning effort was reachable from the
+  REPL only, through `/effort` — which pins a tier by writing the config. A front-end wanting one
+  hard run and one cheap one therefore had to rewrite the user's settings between them. This arms
+  the same per-turn override the REPL arms, for this run and no other: nothing is persisted, and
+  `auto` runs the same keyword-plus-complexity classifier a typed turn goes through. Omitting the
+  flag keeps the old behaviour exactly — the configured `reasoning_effort` applies and the request
+  stays byte-identical to one from a core that never had the flag. The tier is named on stderr.
+
 ## [0.6.5] — 2026-08-17
 
 An OS-level sandbox underneath the approval layer, and an honest per-platform account of what it

--- a/build.rs
+++ b/build.rs
@@ -69,12 +69,20 @@ fn main() {
     fs::write(&dest, gen).expect("build.rs: write prompts_obf.rs");
     println!("cargo:rerun-if-changed=build.rs");
 
-    // Windows MSVC defaults the main thread to a 1 MiB stack. This crate's clap derive
-    // tree + tokio + first-touch statics overflow that budget before `main` can print
-    // --version or run `sandbox doctor` (STATUS_STACK_OVERFLOW 0xC00000FD) in debug.
-    // Bump the PE stack reserve so CI probes and local `cargo run` survive. Use the
-    // target cfg (not host `cfg(windows)`) so cross-builds stay correct.
+    // Windows defaults the main thread to a 1 MiB stack. This crate's clap derive tree +
+    // tokio + first-touch statics overflow that budget before `main` can print --version or
+    // run `sandbox doctor` (STATUS_STACK_OVERFLOW 0xC00000FD) in debug. Bump the PE stack
+    // reserve so CI probes and local `cargo run` survive. Use the target cfg (not host
+    // `cfg(windows)`) so cross-builds stay correct.
+    //
+    // The two Windows toolchains spell it differently, and the flag has to be chosen by
+    // target ENV rather than target OS: `-windows-gnu` is also `target_os = "windows"`, but
+    // GNU ld reads `/STACK:16777216` as a filename and fails the link outright.
     if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
-        println!("cargo:rustc-link-arg=/STACK:16777216");
+        let arg = match env::var("CARGO_CFG_TARGET_ENV").as_deref() {
+            Ok("msvc") => "/STACK:16777216",
+            _ => "-Wl,--stack,16777216",
+        };
+        println!("cargo:rustc-link-arg={arg}");
     }
 }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -350,8 +350,23 @@ The model reads/edits files, runs shell, and uses memory to finish a task end-to
 aizen agent "add a --version flag and update the help text"
 aizen agent --yes "fix the failing test in src/parse.rs"   # pre-approve file/shell ops
 aizen agent --max-iters 40 "..."                            # raise the step cap
+aizen agent --save-session "..."                            # keep the transcript for /sessions
+aizen agent --effort high "..."                             # this run only; the config is untouched
 ```
 Behavior worth knowing:
+- **Nothing is saved unless you ask.** This subcommand is also the scripting and CI entry point, so
+  it writes no session file by default — a file per invocation would bury the pool `/sessions` reads.
+  With `--save-session` the finished conversation is written to `~/.aizen/sessions` with the same
+  provenance stamp the REPL writes (project key, root and slug), so `/sessions` reopens it without
+  caring which surface produced it, and the path is printed to **stderr** — stdout stays the answer.
+  A run that ends in an error is saved too: it still happened.
+- **Effort is per run, not per config.** `/effort` in the REPL pins a tier by writing
+  `reasoning_effort` into the config; `--effort` arms the same per-turn override the REPL arms and
+  persists nothing, so a front-end can send one hard run and one cheap one without editing the
+  user's settings between them. `--effort auto` runs the same keyword-plus-complexity classifier a
+  typed REPL turn goes through, against the task text. Omit the flag and nothing changes: the
+  configured `reasoning_effort` applies and the request is byte-identical to one from a core that
+  never had the flag. The tier is named on **stderr**, next to the rest of the trace.
 - **How tools reach the model** — the session's tool registry is the single source of truth. Its
   definitions (name, description, JSON Schema) are sent through the provider's **native** tool field:
   OpenAI-compatible gateways and Anthropic get `tools[{type:"function",function:{…}}]`, the ChatGPT

--- a/src/cli/run_cmds.rs
+++ b/src/cli/run_cmds.rs
@@ -11,7 +11,7 @@ use crate::cli_args::*;
 use crate::core::approval::ApprovalMode;
 use crate::core::endpoint::{http_client, resolve_base_key, resolve_endpoint};
 use crate::core::types::ToolDef;
-use crate::core::{cli_config, types};
+use crate::core::{cli_config, session_store, types};
 use crate::features::crawl;
 use crate::llm::client;
 use crate::memory;
@@ -331,6 +331,21 @@ pub(crate) async fn run_agent_cmd(args: AgentArgs) -> Result<()> {
     let (base_url, api_key, model) = resolve_endpoint(args.base_url, args.api_key, args.model)?;
     let http = http_client()?;
 
+    // Armed before anything builds a request, and never cleared: a one-shot is one turn, and the
+    // process ends with it. `auto` runs the same classifier a typed REPL turn goes through, so the
+    // two surfaces answer "how hard should this be" the same way.
+    if let Some(want) = args.effort.as_deref() {
+        let tier = match want {
+            "auto" => crate::ui::effort_ui::resolve_turn_effort(args.task.trim()),
+            other => Some(other.to_string()),
+        };
+        eprintln!(
+            "{}",
+            crate::ui::effort_ui::effort_turn_line(tier.as_deref())
+        );
+        cli_config::set_effort_override(tier);
+    }
+
     // Session start: rebuild the always-on core for THIS project slug (STYLE + global prefs
     // only). Do not reuse a stale foreign-repo core.active — refresh_frozen_core is slug-aware.
     let frozen = memory::refresh_frozen_core();
@@ -401,7 +416,17 @@ pub(crate) async fn run_agent_cmd(args: AgentArgs) -> Result<()> {
         }
     };
 
-    let outcome = agent::run_agent(chat, &cfg, &registry, &system, args.task.trim()).await?;
+    // The transcript is built here rather than inside `run_agent` so this path can still hold it
+    // afterwards: the loop appends every turn — the final answer included — to the vector it is
+    // handed, and `run_agent` is exactly these two opening messages plus that call.
+    let mut history = vec![Message::system(&system), Message::user(args.task.trim())];
+    let result = agent::run_agent_loop(chat, &cfg, &registry, &mut history).await;
+    // Saved before the error is propagated. A run that ended badly still happened, and the REPL
+    // treats persistence as not optional — that promise should not be weaker off a terminal.
+    if args.save_session {
+        save_finished_session(&history, &model);
+    }
+    let outcome = result?;
     match outcome.stop {
         // The final answer was already streamed to stdout during the call.
         StopReason::Done => {}
@@ -438,6 +463,28 @@ pub(crate) async fn run_agent_cmd(args: AgentArgs) -> Result<()> {
     Ok(())
 }
 
+/// Put a finished one-shot conversation into core's own session pool, and say where it went.
+///
+/// The stamp is `save_session`'s: project key, root and slug come from `config`, which resolves the
+/// repository this ran in — so a saved one-shot is filed exactly where the same conversation held
+/// in the REPL would have been, and `/sessions` reopens it with no idea which surface produced it.
+///
+/// The line goes to stderr because stdout is the agent's answer: a caller piping it wants the
+/// answer and nothing else.
+fn save_finished_session(history: &[Message], model: &str) {
+    // A run that never got a user turn onto the wire is not a conversation.
+    if !history.iter().any(|m| m.role == "user") {
+        return;
+    }
+    let slug = session_store::allocate_session_slug(history);
+    match session_store::save_session(history, &slug, Some(model)) {
+        Ok(path) => eprintln!("\n[saved as “{slug}” — {path}]"),
+        // Not fatal: the work is done and the answer is already printed. Saying so is the whole
+        // duty here — silence would leave the caller believing there is something to reopen.
+        Err(e) => eprintln!("\n[this session was NOT saved: {e:#}]"),
+    }
+}
+
 pub(crate) async fn run_workflow_cmd(args: WorkflowArgs) -> Result<()> {
     let text = std::fs::read_to_string(&args.spec)
         .with_context(|| format!("reading workflow spec {}", args.spec))?;
@@ -454,4 +501,77 @@ pub(crate) async fn run_workflow_cmd(args: WorkflowArgs) -> Result<()> {
         ApprovalMode::Ask
     };
     agent::workflow::run_workflow(&http, &base_url, &api_key, &model, approval, &spec, trace).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::session_store::{parse_session_bytes, sessions_dir, set_session_slug};
+
+    /// What `--save-session` is FOR: a one-shot run leaves a file the picker can reopen, stamped
+    /// with the project it ran in. The provenance is the point — a transcript on disk that cannot
+    /// say which repo it came from is what makes a per-project session list impossible.
+    #[test]
+    fn a_saved_one_shot_lands_in_the_pool_with_its_provenance() {
+        let _g = crate::core::config::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("aizen-oneshot-save-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("AIZEN_HOME", &home);
+        set_session_slug(None);
+        std::fs::create_dir_all(sessions_dir()).unwrap();
+
+        let history = vec![
+            Message::system("lane"),
+            Message::user("fix the delete button"),
+            Message::assistant("done"),
+        ];
+        save_finished_session(&history, "model-x");
+
+        let files: Vec<_> = std::fs::read_dir(sessions_dir())
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|x| x == "json"))
+            .collect();
+        assert_eq!(files.len(), 1, "one run, one file");
+        // Named from the task rather than a timestamp: the picker is read by a person.
+        let stem = files[0].file_stem().unwrap().to_string_lossy().into_owned();
+        assert!(
+            stem.contains("fix"),
+            "slug should come from the task: {stem}"
+        );
+
+        let (msgs, meta) = parse_session_bytes(&std::fs::read(&files[0]).unwrap())
+            .expect("a transcript we wrote ourselves must be readable");
+        assert_eq!(msgs.len(), 3);
+        let meta = meta.expect("a session written today carries meta");
+        assert_eq!(meta.model.as_deref(), Some("model-x"));
+        assert!(
+            meta.project_root.is_some_and(|r| !r.is_empty()),
+            "without a root, no front-end can tell whose session this is"
+        );
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// A run that never got a question onto the wire is not a conversation, and must not litter the
+    /// pool with an empty file the picker would then offer to restore.
+    #[test]
+    fn a_run_with_no_user_turn_writes_nothing() {
+        let _g = crate::core::config::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("aizen-oneshot-empty-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("AIZEN_HOME", &home);
+        set_session_slug(None);
+        std::fs::create_dir_all(sessions_dir()).unwrap();
+
+        save_finished_session(&[Message::system("lane")], "model-x");
+
+        assert_eq!(std::fs::read_dir(sessions_dir()).unwrap().count(), 0);
+        let _ = std::fs::remove_dir_all(&home);
+    }
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -714,6 +714,15 @@ pub(crate) enum ConfigCmd {
         /// Context window in tokens for the `% context` HUD (overrides auto-detect/heuristic).
         #[arg(long)]
         context_window: Option<usize>,
+        /// Cap on the model's OUTPUT tokens per call — a runaway-completion guard, not a way to
+        /// save input tokens. `0` clears it, back to the provider's own default.
+        #[arg(long)]
+        max_tokens: Option<u32>,
+        /// Anthropic prompt-cache breakpoints, which cut billed INPUT tokens on long sessions:
+        /// `auto` (on when the model id looks Anthropic), `true`, or `false`. A no-op on providers
+        /// that do not cache.
+        #[arg(long)]
+        prompt_cache: Option<String>,
         /// Auto-compact threshold as a percent of context (10–95; `0` disables). Default 80.
         #[arg(long)]
         compact_threshold: Option<u8>,
@@ -723,6 +732,10 @@ pub(crate) enum ConfigCmd {
         /// Auto-learn memory: passively learn durable facts from each turn (default on).
         #[arg(long)]
         memory_auto_learn: Option<bool>,
+        /// Dense-retrieval model for memory recall: a directory name under `~/.aizen/models/`, or
+        /// an absolute path. Empty clears (auto-detect). Only meaningful on a `dense` build.
+        #[arg(long)]
+        embed_model: Option<String>,
         /// Persona evolution: record episodes + reflect them into insights (default on).
         #[arg(long)]
         persona_evolve: Option<bool>,
@@ -738,9 +751,21 @@ pub(crate) enum ConfigCmd {
         /// Final-answer visuals: `auto` (when useful), `always` (substantial replies), or `off`.
         #[arg(long)]
         response_visuals: Option<String>,
+        /// Silent background release check at REPL startup (cached 24h, one line at most).
+        /// `AIZEN_NO_UPDATE_CHECK` disables it without touching the file.
+        #[arg(long)]
+        update_check: Option<bool>,
+        /// Skill marketplace base URL for `skill search`/`skill install`. Empty restores the
+        /// default registry.
+        #[arg(long)]
+        skill_registry: Option<String>,
         /// Time-machine checkpoints to keep (oldest auto-pruned past this; `0` = unlimited). Default 50.
         #[arg(long)]
         timemachine_keep: Option<usize>,
+        /// Safety-net checkpoints (`before agent edits`) to keep, pruned before any named
+        /// milestone is touched. Default 5.
+        #[arg(long)]
+        timemachine_keep_safety: Option<usize>,
         /// Maximum number of files in one Time Machine snapshot.
         #[arg(long)]
         timemachine_max_files: Option<u64>,
@@ -768,12 +793,41 @@ pub(crate) enum ConfigCmd {
         /// hardest turns (opt-in; default off).
         #[arg(long)]
         adaptive_effort: Option<bool>,
+        /// System-prompt tier: `full`, or `strict` (the compact numbered-rules prompt for small or
+        /// local models). Empty restores the by-model heuristic.
+        #[arg(long)]
+        prompt_tier: Option<String>,
+        /// Eager tool execution while streaming: read-only calls start as soon as their arguments
+        /// finish streaming (default on). `AIZEN_NO_EAGER` is the env kill-switch.
+        #[arg(long)]
+        eager_tools: Option<bool>,
+        /// One extra self-review turn before Done on runs that edited files. Unset ⇒ off, unless a
+        /// `roles.oracle` model is configured, which turns it on by itself.
+        #[arg(long)]
+        self_review: Option<bool>,
+        /// Persist the sandbox mode (`sandbox.mode`): auto | strict | guarded | off. Unlike the
+        /// global `--sandbox`, which overrides one invocation, this one is written to the config.
+        #[arg(long)]
+        sandbox_mode: Option<String>,
         /// Comma-separated tool bundles to hide.
         #[arg(long)]
         disabled_toolsets: Option<String>,
         /// Comma-separated tool-bundle whitelist.
         #[arg(long)]
         enabled_toolsets: Option<String>,
+        /// Concurrent sub-agent cap for `task` fan-out and workflows. `0` clears it, back to the
+        /// machine-derived band (2–16).
+        #[arg(long)]
+        max_subagents: Option<usize>,
+        /// Register the `workflow` fan-out tool (default on). Off saves its ~350-token schema on
+        /// every top-level turn.
+        #[arg(long)]
+        workflow_tool: Option<bool>,
+        /// Saved provider profile the sub-agent default runs on (`roles.subagent_default.provider`);
+        /// its endpoint and default model are inherited. The preferred way to route a role — the
+        /// base-url/key pair below is the older, per-field spelling. Empty clears.
+        #[arg(long)]
+        subagent_provider: Option<String>,
         /// Default model for dispatched sub-agents (`roles.subagent_default`). Routes through the
         /// model→endpoint registry, so pairing it with `--model-endpoint` runs sub-agents on their
         /// own gateway. Pass an empty string to clear.
@@ -787,6 +841,9 @@ pub(crate) enum ConfigCmd {
         /// key. Empty clears. (`roles.subagent_default.api_key_ref`.)
         #[arg(long)]
         subagent_api_key_ref: Option<String>,
+        /// Saved provider profile the summarizer runs on (`roles.summarizer.provider`). Empty clears.
+        #[arg(long)]
+        summarizer_provider: Option<String>,
         /// Model for compaction/handoff summaries (`roles.summarizer`) — the classic cheap-model
         /// slot. Empty clears.
         #[arg(long)]
@@ -798,6 +855,9 @@ pub(crate) enum ConfigCmd {
         /// Empty clears. (`roles.summarizer.api_key_ref`.)
         #[arg(long)]
         summarizer_api_key_ref: Option<String>,
+        /// Saved provider profile the reviewer runs on (`roles.oracle.provider`). Empty clears.
+        #[arg(long)]
+        oracle_provider: Option<String>,
         /// Model for the self-review reviewer (`roles.oracle`) — a stronger model is the point.
         /// NOTE: configuring this role also TURNS SELF-REVIEW ON unless `self_review` says otherwise.
         /// Empty clears.
@@ -810,6 +870,9 @@ pub(crate) enum ConfigCmd {
         /// Empty clears. (`roles.oracle.api_key_ref`.)
         #[arg(long)]
         oracle_api_key_ref: Option<String>,
+        /// Saved provider profile the apply role runs on (`roles.apply.provider`). Empty clears.
+        #[arg(long)]
+        apply_provider: Option<String>,
         /// Model for the reserved fast-apply edit role (`roles.apply`; config-only today). Empty clears.
         #[arg(long)]
         apply_model: Option<String>,
@@ -962,6 +1025,16 @@ pub(crate) struct AgentArgs {
     /// Hard step cap before the one-shot auto-extend (default 25).
     #[arg(long)]
     pub(crate) max_iters: Option<usize>,
+    /// Save the finished conversation under ~/.aizen/sessions, so /sessions can reopen it.
+    /// Off by default: this subcommand is also the scripting and CI entry point, and a file per
+    /// invocation would bury the pool the picker reads.
+    #[arg(long)]
+    pub(crate) save_session: bool,
+    /// Reasoning effort for this run: auto | low | medium | high | xhigh | max. `auto` classifies
+    /// the task the way the REPL classifies a typed turn. Omitted ⇒ the configured
+    /// `reasoning_effort` is used, exactly as before. This flag never writes the config.
+    #[arg(long, value_parser = ["auto", "low", "medium", "high", "xhigh", "max"])]
+    pub(crate) effort: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -58,6 +58,9 @@ struct SearchResponse {
     data: Vec<RegistrySkill>,
     #[serde(default)]
     total: usize,
+    /// Whether another page exists — the browse fallback stops rather than asking past the end.
+    #[serde(default, rename = "hasMore")]
+    has_more: bool,
 }
 
 /// The by-slug record, from the route that serves one named skill. It carries the markdown itself
@@ -130,7 +133,92 @@ pub fn registry_base() -> String {
 }
 
 /// Search the registry by keyword. `limit` caps results. SSRF-guarded (see the module doc).
+///
+/// The keyword index is asked first and, when it fails, is not the last word: the catalogue is
+/// still served page by page, and matching the query against those pages here finds the same rows
+/// the index would have. Slower, and only on the failing path — but a registry whose search is
+/// down is not a registry with no skills on it, and for a day of HTTP 500s that is exactly how
+/// this read to everyone using it.
 pub async fn search(query: &str, limit: usize) -> Result<Vec<RegistrySkill>> {
+    let indexed = match search_index(query, limit).await {
+        Ok(hits) => return Ok(hits),
+        Err(e) => e,
+    };
+    // Nothing found by hand does not disprove the index — say what actually went wrong instead of
+    // reporting an empty catalogue.
+    match browse_match(query, limit).await {
+        Ok(hits) if !hits.is_empty() => Ok(hits),
+        _ => Err(indexed),
+    }
+}
+
+/// Every word of the query has to appear somewhere in what the row says about itself — the way a
+/// person reading down the catalogue would match it.
+fn matches(sk: &RegistrySkill, words: &[String]) -> bool {
+    let hay = format!("{} {} {}", sk.id(), sk.name, sk.description).to_lowercase();
+    words.iter().all(|w| hay.contains(w.as_str()))
+}
+
+/// How far down the catalogue the fallback is willing to read. Bounded on purpose: this runs only
+/// when the index is down, and a search that quietly turns into hundreds of requests is its own
+/// kind of outage.
+const BROWSE_PAGES: usize = 12;
+const BROWSE_PAGE_SIZE: usize = 100;
+
+/// Page the listing route and filter locally. Stops at the first full page of results, at the end
+/// of the catalogue, or at `BROWSE_PAGES` — whichever comes first.
+async fn browse_match(query: &str, limit: usize) -> Result<Vec<RegistrySkill>> {
+    let words: Vec<String> = query
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .filter(|w| !w.is_empty())
+        .collect();
+    if words.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+    let base = registry_base();
+    let client = crate::agent::reach::http::client()?;
+    let mut out: Vec<RegistrySkill> = Vec::new();
+    for page in 1..=BROWSE_PAGES {
+        let url = reqwest::Url::parse_with_params(
+            &format!("{}/api/skills", base.trim_end_matches('/')),
+            &[
+                ("limit", BROWSE_PAGE_SIZE.to_string()),
+                ("page", page.to_string()),
+            ],
+        )
+        .with_context(|| format!("bad registry base '{base}'"))?;
+        crate::core::net_guard::guard_url_async(url.as_str()).await?;
+        let f = crate::agent::reach::http::get(&client, url.as_str(), &[])
+            .await
+            .with_context(|| format!("reading the catalogue on {base}"))?;
+        if !f.is_success() {
+            break;
+        }
+        let Ok(parsed) = serde_json::from_slice::<SearchResponse>(&f.body) else {
+            break;
+        };
+        if parsed.data.is_empty() {
+            break;
+        }
+        let more = parsed.has_more;
+        for sk in parsed.data {
+            if matches(&sk, &words) && !out.iter().any(|o| o.id() == sk.id()) {
+                out.push(sk);
+                if out.len() >= limit {
+                    return Ok(out);
+                }
+            }
+        }
+        if !more {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// Ask the registry's own keyword index.
+async fn search_index(query: &str, limit: usize) -> Result<Vec<RegistrySkill>> {
     let base = registry_base();
     let url = reqwest::Url::parse_with_params(
         &format!("{}/api/skills", base.trim_end_matches('/')),
@@ -223,13 +311,8 @@ fn save_body(fallback: &str, body_md: &str) -> Result<crate::skills::Skill> {
 pub async fn install(query: &str) -> Result<crate::skills::Skill> {
     let q = query.trim();
     if q.contains('/') {
-        if let Some(direct) = by_slug(q).await? {
-            let fallback = if direct.name.trim().is_empty() {
-                q.rsplit('/').next().unwrap_or(q)
-            } else {
-                direct.name.trim()
-            };
-            return save_body(fallback, &direct.skill_md);
+        if let Some(saved) = install_by_slug(q, q).await? {
+            return Ok(saved);
         }
     }
 
@@ -243,8 +326,36 @@ pub async fn install(query: &str) -> Result<crate::skills::Skill> {
         .find(|s| s.id().to_lowercase() == want || s.name.to_lowercase() == want)
         .unwrap_or(&hits[0])
         .clone();
+
+    // The registry's own copy before GitHub's. Its stored coordinates are a snapshot of where the
+    // file was, and repositories move: `bytedance/frontend-design` is listed at a path that now
+    // answers 404, while the registry still serves the same skill by slug. Falling at that fence
+    // would fail an install for a reason that has nothing to do with the skill.
+    if let Some(saved) = install_by_slug(&chosen.id(), &chosen.name).await? {
+        return Ok(saved);
+    }
     let body_md = fetch_body(&chosen).await?;
     save_body(&chosen.name, &body_md)
+}
+
+/// Fetch `slug` from the registry's by-slug route and save it. `Ok(None)` when that route has
+/// nothing for this slug, which leaves the caller free to try GitHub.
+async fn install_by_slug(slug: &str, name_hint: &str) -> Result<Option<crate::skills::Skill>> {
+    let Some(direct) = by_slug(slug).await? else {
+        return Ok(None);
+    };
+    let fallback = [direct.name.trim(), name_hint.trim()]
+        .into_iter()
+        .find(|n| !n.is_empty())
+        .unwrap_or(slug)
+        .to_string();
+    // A bare `owner/` is not a name to save a file under.
+    let fallback = fallback
+        .rsplit('/')
+        .find(|p| !p.is_empty())
+        .unwrap_or(slug)
+        .to_string();
+    save_body(&fallback, &direct.skill_md).map(Some)
 }
 
 /// Bridge an async future to the sync `Tool::execute` path — the shared cancel-aware bridge
@@ -411,6 +522,49 @@ mod tests {
                 .as_str(),
             "https://agentskill.sh/api/agent/skills/..%2F..%2Fetc/install"
         );
+    }
+
+    /// The fallback matches on what a row says about itself, and only on all of the words —
+    /// otherwise a two-word query returns everything that shares its commonest half.
+    #[test]
+    fn the_browse_fallback_matches_every_word_or_none() {
+        let mut sk = RegistrySkill {
+            name: "frontend-design".into(),
+            slug: "bytedance/frontend-design".into(),
+            description: "Create distinctive, production-grade interfaces".into(),
+            ..Default::default()
+        };
+        let words =
+            |q: &str| -> Vec<String> { q.split_whitespace().map(str::to_lowercase).collect() };
+        assert!(matches(&sk, &words("frontend")));
+        assert!(
+            matches(&sk, &words("FRONTEND")),
+            "case is not a distinction"
+        );
+        assert!(matches(&sk, &words("frontend interfaces")));
+        assert!(
+            matches(&sk, &words("bytedance")),
+            "the owner is part of the row"
+        );
+        assert!(
+            !matches(&sk, &words("frontend rust")),
+            "both words or neither"
+        );
+        assert!(!matches(&sk, &words("kubernetes")));
+        // A row that says nothing about itself matches nothing but its own name.
+        sk.description = String::new();
+        assert!(!matches(&sk, &words("interfaces")));
+    }
+
+    /// The listing's paging flag is read, so the fallback stops at the end of the catalogue rather
+    /// than asking twelve times for a page that is not there.
+    #[test]
+    fn the_listing_says_whether_another_page_exists() {
+        let body = r#"{"data":[],"total":4,"page":2,"limit":100,"hasMore":true}"#;
+        let r: SearchResponse = serde_json::from_str(body).unwrap();
+        assert!(r.has_more);
+        let last: SearchResponse = serde_json::from_str(r#"{"data":[]}"#).unwrap();
+        assert!(!last.has_more, "a response that omits it has no more pages");
     }
 
     /// The by-slug record is the whole install: markdown in hand, no GitHub round trip.

--- a/src/skills/registry.rs
+++ b/src/skills/registry.rs
@@ -60,6 +60,17 @@ struct SearchResponse {
     total: usize,
 }
 
+/// The by-slug record, from the route that serves one named skill. It carries the markdown itself
+/// rather than GitHub coordinates, so an install through it never leaves the registry.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DirectSkill {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    skill_md: String,
+}
+
 impl RegistrySkill {
     /// `owner/name` identifier (prefers the API `slug`).
     pub fn id(&self) -> String {
@@ -157,29 +168,83 @@ pub async fn fetch_body(sk: &RegistrySkill) -> Result<String> {
     Ok(f.text())
 }
 
-/// Search → pick the exact-slug match (else the first hit) → fetch + save locally. Returns the
-/// saved skill. Used by both the `aizen skill install` CLI and the `skill_install` agent tool.
+/// The URL that serves one skill by its `owner/name`. Built through `path_segments_mut` so the
+/// slash inside the slug is encoded as a slug and cannot become another path segment — a name is
+/// data here, and a registry route is not a place to let data spell itself.
+fn by_slug_url(base: &str, slug: &str) -> Result<reqwest::Url> {
+    let mut url = reqwest::Url::parse(base.trim_end_matches('/'))
+        .with_context(|| format!("bad registry base '{base}'"))?;
+    url.path_segments_mut()
+        .map_err(|_| anyhow::anyhow!("registry base '{base}' cannot hold a path"))?
+        .pop_if_empty()
+        .extend(["api", "agent", "skills", slug, "install"]);
+    Ok(url)
+}
+
+/// Fetch one skill by `owner/name`. `Ok(None)` means the registry does not serve this route or
+/// does not know the slug — both are reasons to fall back to a search, not reasons to fail.
+async fn by_slug(slug: &str) -> Result<Option<DirectSkill>> {
+    let base = registry_base();
+    let url = by_slug_url(&base, slug)?;
+    crate::core::net_guard::guard_url_async(url.as_str()).await?;
+    let client = crate::agent::reach::http::client()?;
+    let f = crate::agent::reach::http::get(&client, url.as_str(), &[])
+        .await
+        .with_context(|| format!("asking {base} for '{slug}'"))?;
+    if !f.is_success() {
+        return Ok(None);
+    }
+    let got: DirectSkill = match serde_json::from_slice(&f.body) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    Ok((!got.skill_md.trim().is_empty()).then_some(got))
+}
+
+/// Parse one skill's markdown and save it locally, under its own `name:` when it declares one.
+fn save_body(fallback: &str, body_md: &str) -> Result<crate::skills::Skill> {
+    let parsed = crate::skills::parse_markdown(body_md, &crate::skills::sanitize_name(fallback));
+    let name = if parsed.name.trim().is_empty() {
+        fallback.to_string()
+    } else {
+        parsed.name.clone()
+    };
+    crate::skills::save(&name, &parsed.description, &parsed.when, &parsed.body)?;
+    Ok(crate::skills::Skill { name, ..parsed })
+}
+
+/// Install one skill by name. An exact `owner/name` is fetched by slug; anything else is a search
+/// followed by the best match.
+///
+/// The by-slug route first because an install by exact name never needed the search index, and
+/// borrowing it meant borrowing its outages: when agentskill.sh's index began answering HTTP 500
+/// (2026-08-18) every `skill install` failed too, though every skill on it was still being served.
+/// A dependency that only ever costs you is one to drop.
 pub async fn install(query: &str) -> Result<crate::skills::Skill> {
-    let hits = search(query, DEFAULT_LIMIT).await?;
+    let q = query.trim();
+    if q.contains('/') {
+        if let Some(direct) = by_slug(q).await? {
+            let fallback = if direct.name.trim().is_empty() {
+                q.rsplit('/').next().unwrap_or(q)
+            } else {
+                direct.name.trim()
+            };
+            return save_body(fallback, &direct.skill_md);
+        }
+    }
+
+    let hits = search(q, DEFAULT_LIMIT).await?;
     if hits.is_empty() {
         bail!("no skill on {} matches '{query}'", registry_base());
     }
-    let want = query.trim().to_lowercase();
+    let want = q.to_lowercase();
     let chosen = hits
         .iter()
         .find(|s| s.id().to_lowercase() == want || s.name.to_lowercase() == want)
         .unwrap_or(&hits[0])
         .clone();
     let body_md = fetch_body(&chosen).await?;
-    let parsed =
-        crate::skills::parse_markdown(&body_md, &crate::skills::sanitize_name(&chosen.name));
-    let name = if parsed.name.trim().is_empty() {
-        chosen.name.clone()
-    } else {
-        parsed.name.clone()
-    };
-    crate::skills::save(&name, &parsed.description, &parsed.when, &parsed.body)?;
-    Ok(crate::skills::Skill { name, ..parsed })
+    save_body(&chosen.name, &body_md)
 }
 
 /// Bridge an async future to the sync `Tool::execute` path — the shared cancel-aware bridge
@@ -320,6 +385,45 @@ mod tests {
         );
         // missing coordinates → None
         assert_eq!(RegistrySkill::default().raw_url(), None);
+    }
+
+    /// The slug is one path segment, however many slashes it contains. If it ever stopped being
+    /// one, `a/../b` would address something other than the skill named `a/../b`.
+    #[test]
+    fn a_slug_is_one_encoded_segment() {
+        assert_eq!(
+            by_slug_url("https://agentskill.sh", "agentskill-sh/learn")
+                .unwrap()
+                .as_str(),
+            "https://agentskill.sh/api/agent/skills/agentskill-sh%2Flearn/install"
+        );
+        // A base with its own path keeps it, and a trailing slash does not become an empty segment.
+        assert_eq!(
+            by_slug_url("https://reg.example.com/aizen/", "o/n")
+                .unwrap()
+                .as_str(),
+            "https://reg.example.com/aizen/api/agent/skills/o%2Fn/install"
+        );
+        // Traversal is data, not structure.
+        assert_eq!(
+            by_slug_url("https://agentskill.sh", "../../etc")
+                .unwrap()
+                .as_str(),
+            "https://agentskill.sh/api/agent/skills/..%2F..%2Fetc/install"
+        );
+    }
+
+    /// The by-slug record is the whole install: markdown in hand, no GitHub round trip.
+    #[test]
+    fn a_direct_record_carries_the_markdown() {
+        let body = r#"{"slug":"o/n","name":"learn","skillMd":"---\nname: learn\n---\nsteps",
+            "installCount":5,"securityScore":90}"#;
+        let d: DirectSkill = serde_json::from_str(body).unwrap();
+        assert_eq!(d.name, "learn");
+        assert!(d.skill_md.contains("steps"));
+        // A record without a body is not an install — `by_slug` treats it as a miss.
+        let empty: DirectSkill = serde_json::from_str(r#"{"name":"x"}"#).unwrap();
+        assert!(empty.skill_md.is_empty());
     }
 
     #[test]

--- a/src/tests/config_ui.rs
+++ b/src/tests/config_ui.rs
@@ -188,6 +188,7 @@ fn apply_role_flags_sets_clears_then_drops_the_role() {
     apply_role_flags(
         &mut roles,
         "oracle",
+        None,
         Some("strong-model".into()),
         Some("https://oracle/v1".into()),
         None,
@@ -199,7 +200,7 @@ fn apply_role_flags_sets_clears_then_drops_the_role() {
     assert!(roles.has_any());
 
     // A `None` for every field is a no-op, not a wipe.
-    apply_role_flags(&mut roles, "oracle", None, None, None);
+    apply_role_flags(&mut roles, "oracle", None, None, None, None);
     assert_eq!(
         roles.oracle.as_ref().unwrap().model.as_deref(),
         Some("strong-model"),
@@ -207,10 +208,10 @@ fn apply_role_flags_sets_clears_then_drops_the_role() {
     );
 
     // Empty strings clear individual fields; emptying them all drops the role entirely.
-    apply_role_flags(&mut roles, "oracle", Some(String::new()), None, None);
+    apply_role_flags(&mut roles, "oracle", None, Some(String::new()), None, None);
     assert_eq!(roles.oracle.as_ref().unwrap().model, None, "model cleared");
     assert!(roles.oracle.is_some(), "base_url still holds the role open");
-    apply_role_flags(&mut roles, "oracle", None, Some("  ".into()), None);
+    apply_role_flags(&mut roles, "oracle", None, None, Some("  ".into()), None);
     assert!(
         roles.oracle.is_none(),
         "an all-empty role is removed, not left as a husk"
@@ -218,11 +219,51 @@ fn apply_role_flags_sets_clears_then_drops_the_role() {
     assert!(!roles.has_any());
 
     // Each role writes to its own slot.
-    apply_role_flags(&mut roles, "summarizer", Some("cheap".into()), None, None);
-    apply_role_flags(&mut roles, "apply", Some("fast".into()), None, None);
+    apply_role_flags(
+        &mut roles,
+        "summarizer",
+        None,
+        Some("cheap".into()),
+        None,
+        None,
+    );
+    apply_role_flags(&mut roles, "apply", None, Some("fast".into()), None, None);
     assert_eq!(roles.summarizer.unwrap().model.as_deref(), Some("cheap"));
     assert_eq!(roles.apply.unwrap().model.as_deref(), Some("fast"));
     assert!(roles.oracle.is_none() && roles.subagent_default.is_none());
+}
+/// The profile route (`roles.<role>.provider`) holds a role open exactly as the per-field
+/// overrides do, and clears the same way — it is the spelling core's own struct calls preferred,
+/// so it must not be the one with weaker guarantees.
+#[test]
+fn a_role_pinned_to_a_profile_sets_and_clears_like_any_other_field() {
+    let mut roles = cli_config::RolesConfig::default();
+    apply_role_flags(&mut roles, "oracle", Some("work".into()), None, None, None);
+    assert_eq!(
+        roles.oracle.as_ref().unwrap().provider.as_deref(),
+        Some("work")
+    );
+
+    apply_role_flags(&mut roles, "oracle", Some(String::new()), None, None, None);
+    assert!(
+        roles.oracle.is_none(),
+        "the profile was the role's only field, so clearing it drops the role"
+    );
+
+    // A per-role effort nobody can set from the CLI still counts as the role being configured:
+    // clearing the fields we *can* see must not take a hand-written one down with it.
+    let mut roles = cli_config::RolesConfig::default();
+    roles.oracle = Some(cli_config::RoleModelConfig {
+        model: Some("strong".into()),
+        reasoning_effort: Some("xhigh".into()),
+        ..Default::default()
+    });
+    apply_role_flags(&mut roles, "oracle", None, Some(String::new()), None, None);
+    assert_eq!(
+        roles.oracle.as_ref().unwrap().reasoning_effort.as_deref(),
+        Some("xhigh"),
+        "clearing the model must not discard the effort beside it"
+    );
 }
 #[test]
 fn version_suffix_hint_only_when_actually_missing() {

--- a/src/tests/main_suite.rs
+++ b/src/tests/main_suite.rs
@@ -79,6 +79,56 @@ fn agents_set_provider_parses() {
     ));
 }
 
+/// `--save-session` is a switch, not a value.
+///
+/// The task is positional, so a flag that took an optional NAME here would swallow it: the very
+/// natural `aizen agent --save-session "fix the delete button"` would file an empty task under a
+/// session called "fix the delete button". Keeping the flag boolean is what makes that impossible,
+/// and this test is the reason it must stay boolean.
+#[test]
+fn agent_save_session_is_a_switch_and_never_eats_the_task() {
+    let cli = Cli::try_parse_from(["aizen", "agent", "--save-session", "sửa cái nút xoá"])
+        .expect("parse");
+    let Some(Commands::Agent(args)) = cli.command else {
+        panic!("expected the agent subcommand");
+    };
+    assert!(args.save_session);
+    assert_eq!(args.task, "sửa cái nút xoá");
+
+    // Off unless asked: the scripting path must not start writing files because it was upgraded.
+    let plain = Cli::try_parse_from(["aizen", "agent", "chạy test"]).expect("parse");
+    assert!(matches!(plain.command, Some(Commands::Agent(a)) if !a.save_session));
+}
+
+/// The rungs `--effort` accepts are the rungs `reasoning_effort` goes out with, plus `auto`.
+///
+/// Validated by clap rather than at use: a typo like `--effort mediumish` reaching the wire would
+/// come back as a provider error several seconds and one billed prompt later, and that message
+/// would be about the request rather than about the flag.
+#[test]
+fn agent_effort_takes_the_ladder_and_nothing_else() {
+    let effort_of = |argv: &[&str]| -> Option<String> {
+        let cli = Cli::try_parse_from(argv).expect("parse");
+        match cli.command {
+            Some(Commands::Agent(a)) => a.effort,
+            _ => panic!("expected the agent subcommand"),
+        }
+    };
+
+    for tier in ["auto", "low", "medium", "high", "xhigh", "max"] {
+        assert_eq!(
+            effort_of(&["aizen", "agent", "--effort", tier, "việc"]).as_deref(),
+            Some(tier)
+        );
+    }
+
+    // Omitted is its own answer: the configured `reasoning_effort` applies, and the request stays
+    // byte-identical to one from a core that never had this flag.
+    assert_eq!(effort_of(&["aizen", "agent", "việc"]), None);
+
+    assert!(Cli::try_parse_from(["aizen", "agent", "--effort", "mediumish", "việc"]).is_err());
+}
+
 /// `memory list current` and `memory list --scope current` must mean the same thing.
 ///
 /// The REPL has always taken the scope positionally (`/memory list current`), so that is the form

--- a/src/ui/config_ui.rs
+++ b/src/ui/config_ui.rs
@@ -71,20 +71,25 @@ fn apply_model_endpoint(cfg: &mut cli_config::CliConfig, spec: &str) -> Result<(
     Ok(())
 }
 
-/// Apply one role's `--<role>-model/-base-url/-api-key-ref` trio to `roles`.
+/// Apply one role's `--<role>-provider/-model/-base-url/-api-key-ref` set to `roles`.
 ///
 /// `None` leaves a field alone; an EMPTY string clears it (the documented way to undo a setting
 /// without hand-editing JSON). When every field of the role ends up cleared, the role object itself
 /// is dropped so the saved config doesn't accumulate `"oracle": {}` husks — which matters beyond
 /// tidiness, because `role_configured("oracle")` (and therefore self-review) keys off presence.
+///
+/// `reasoning_effort` is not settable here, but it is counted: it is a field of the role, and a
+/// role emptied of the fields this function *can* see would otherwise take a hand-written per-role
+/// effort down with it.
 fn apply_role_flags(
     roles: &mut cli_config::RolesConfig,
     role: &str,
+    provider: Option<String>,
     model: Option<String>,
     base_url: Option<String>,
     api_key_ref: Option<String>,
 ) {
-    if model.is_none() && base_url.is_none() && api_key_ref.is_none() {
+    if provider.is_none() && model.is_none() && base_url.is_none() && api_key_ref.is_none() {
         return;
     }
     let slot = match role {
@@ -101,10 +106,16 @@ fn apply_role_flags(
             *field = (!s.is_empty()).then(|| s.to_string());
         }
     };
+    set(&mut rc.provider, provider);
     set(&mut rc.model, model);
     set(&mut rc.base_url, base_url);
     set(&mut rc.api_key_ref, api_key_ref);
-    *slot = (rc.model.is_some() || rc.base_url.is_some() || rc.api_key_ref.is_some()).then_some(rc);
+    *slot = (rc.provider.is_some()
+        || rc.model.is_some()
+        || rc.base_url.is_some()
+        || rc.api_key_ref.is_some()
+        || rc.reasoning_effort.is_some())
+    .then_some(rc);
 }
 
 pub(crate) async fn run_auth(cmd: AuthCmd) -> Result<()> {
@@ -165,15 +176,21 @@ pub(crate) async fn run_config(cmd: Option<ConfigCmd>) -> Result<()> {
             api_key,
             model,
             context_window,
+            max_tokens,
+            prompt_cache,
             compact_threshold,
             auto_skill_learn,
             memory_auto_learn,
+            embed_model,
             persona_evolve,
             price_in,
             price_out,
             icons,
             response_visuals,
+            update_check,
+            skill_registry,
             timemachine_keep,
+            timemachine_keep_safety,
             timemachine_max_files,
             timemachine_max_bytes,
             timemachine_max_file_bytes,
@@ -182,70 +199,113 @@ pub(crate) async fn run_config(cmd: Option<ConfigCmd>) -> Result<()> {
             approval,
             ultimate,
             adaptive_effort,
+            prompt_tier,
+            eager_tools,
+            self_review,
+            sandbox_mode,
             disabled_toolsets,
             enabled_toolsets,
+            max_subagents,
+            workflow_tool,
+            subagent_provider,
             subagent_model,
             subagent_base_url,
             subagent_api_key_ref,
+            summarizer_provider,
             summarizer_model,
             summarizer_base_url,
             summarizer_api_key_ref,
+            oracle_provider,
             oracle_model,
             oracle_base_url,
             oracle_api_key_ref,
+            apply_provider,
             apply_model,
             apply_base_url,
             apply_api_key_ref,
             model_endpoint,
         } => {
-            // (role, model, base_url, api_key_ref) — one table so the emptiness guard below and the
-            // apply loop further down can never disagree about which flags exist.
+            // (role, provider, model, base_url, api_key_ref) — one table so the emptiness guard
+            // below and the apply loop further down can never disagree about which flags exist.
             let role_flags = [
                 (
                     "subagent_default",
+                    subagent_provider,
                     subagent_model,
                     subagent_base_url,
                     subagent_api_key_ref,
                 ),
                 (
                     "summarizer",
+                    summarizer_provider,
                     summarizer_model,
                     summarizer_base_url,
                     summarizer_api_key_ref,
                 ),
-                ("oracle", oracle_model, oracle_base_url, oracle_api_key_ref),
-                ("apply", apply_model, apply_base_url, apply_api_key_ref),
+                (
+                    "oracle",
+                    oracle_provider,
+                    oracle_model,
+                    oracle_base_url,
+                    oracle_api_key_ref,
+                ),
+                (
+                    "apply",
+                    apply_provider,
+                    apply_model,
+                    apply_base_url,
+                    apply_api_key_ref,
+                ),
             ];
             let any_role_flag = role_flags
                 .iter()
-                .any(|(_, m, b, k)| m.is_some() || b.is_some() || k.is_some());
-            if base_url.is_none()
-                && api_key.is_none()
-                && model.is_none()
-                && context_window.is_none()
-                && compact_threshold.is_none()
-                && auto_skill_learn.is_none()
-                && memory_auto_learn.is_none()
-                && persona_evolve.is_none()
-                && price_in.is_none()
-                && price_out.is_none()
-                && icons.is_none()
-                && response_visuals.is_none()
-                && timemachine_keep.is_none()
-                && timemachine_max_files.is_none()
-                && timemachine_max_bytes.is_none()
-                && timemachine_max_file_bytes.is_none()
-                && auto_effort.is_none()
-                && reasoning_effort.is_none()
-                && approval.is_none()
-                && ultimate.is_none()
-                && adaptive_effort.is_none()
-                && disabled_toolsets.is_none()
-                && enabled_toolsets.is_none()
-                && !any_role_flag
-                && model_endpoint.is_empty()
-            {
-                anyhow::bail!("nothing to set — pass at least one supported --flag (including --timemachine-keep / --timemachine-max-files / --timemachine-max-bytes / --timemachine-max-file-bytes)");
+                .any(|(_, p, m, b, k)| p.is_some() || m.is_some() || b.is_some() || k.is_some());
+            // One list rather than a thirty-term `&&` chain: a flag added to the enum and forgotten
+            // here would make `config set --that-flag` bail with "nothing to set" while quietly
+            // doing nothing, and a chain that long is exactly where that omission hides.
+            let any_scalar_flag = [
+                base_url.is_some(),
+                api_key.is_some(),
+                model.is_some(),
+                context_window.is_some(),
+                max_tokens.is_some(),
+                prompt_cache.is_some(),
+                compact_threshold.is_some(),
+                auto_skill_learn.is_some(),
+                memory_auto_learn.is_some(),
+                embed_model.is_some(),
+                persona_evolve.is_some(),
+                price_in.is_some(),
+                price_out.is_some(),
+                icons.is_some(),
+                response_visuals.is_some(),
+                update_check.is_some(),
+                skill_registry.is_some(),
+                timemachine_keep.is_some(),
+                timemachine_keep_safety.is_some(),
+                timemachine_max_files.is_some(),
+                timemachine_max_bytes.is_some(),
+                timemachine_max_file_bytes.is_some(),
+                auto_effort.is_some(),
+                reasoning_effort.is_some(),
+                approval.is_some(),
+                ultimate.is_some(),
+                adaptive_effort.is_some(),
+                prompt_tier.is_some(),
+                eager_tools.is_some(),
+                self_review.is_some(),
+                sandbox_mode.is_some(),
+                disabled_toolsets.is_some(),
+                enabled_toolsets.is_some(),
+                max_subagents.is_some(),
+                workflow_tool.is_some(),
+            ]
+            .into_iter()
+            .any(|set| set);
+            if !any_scalar_flag && !any_role_flag && model_endpoint.is_empty() {
+                anyhow::bail!(
+                    "nothing to set — pass at least one flag; `aizen config set --help` lists them"
+                );
             }
             let mut cfg = cli_config::load();
             let previous_url = cfg.base_url.clone();
@@ -264,6 +324,21 @@ pub(crate) async fn run_config(cmd: Option<ConfigCmd>) -> Result<()> {
             if let Some(w) = context_window {
                 cfg.model_context_window = if w > 0 { Some(w) } else { None };
             }
+            if let Some(n) = max_tokens {
+                cfg.max_tokens = (n > 0).then_some(n); // 0 ⇒ back to the provider's own ceiling
+            }
+            if let Some(v) = prompt_cache {
+                // Three states, not two: `auto` is a real answer here (decide by model id), so it
+                // has to be sayable — a boolean flag could set the field but never unset it.
+                cfg.prompt_cache = match v.trim().to_ascii_lowercase().as_str() {
+                    "auto" => None,
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    other => anyhow::bail!(
+                        "--prompt-cache must be one of: auto, true, false (got '{other}')"
+                    ),
+                };
+            }
             if let Some(t) = compact_threshold {
                 if t != 0 && !(10..=95).contains(&t) {
                     anyhow::bail!("--compact-threshold must be 0 (off) or 10–95");
@@ -275,6 +350,10 @@ pub(crate) async fn run_config(cmd: Option<ConfigCmd>) -> Result<()> {
             }
             if let Some(b) = memory_auto_learn {
                 cfg.memory_auto_learn = Some(b);
+            }
+            if let Some(v) = embed_model {
+                let v = v.trim();
+                cfg.embed_model = (!v.is_empty()).then(|| v.to_string());
             }
             if let Some(b) = persona_evolve {
                 cfg.persona_evolve = Some(b);
@@ -304,8 +383,25 @@ pub(crate) async fn run_config(cmd: Option<ConfigCmd>) -> Result<()> {
                         .map_err(anyhow::Error::msg)?,
                 );
             }
+            if let Some(b) = update_check {
+                cfg.update_check = Some(b);
+            }
+            if let Some(v) = skill_registry {
+                let v = v.trim().trim_end_matches('/');
+                if v.is_empty() {
+                    cfg.skill_registry = None; // back to the default marketplace
+                } else {
+                    if !v.starts_with("http://") && !v.starts_with("https://") {
+                        anyhow::bail!("--skill-registry must be an http:// or https:// URL");
+                    }
+                    cfg.skill_registry = Some(v.to_string());
+                }
+            }
             if let Some(k) = timemachine_keep {
                 cfg.timemachine_keep = Some(k); // 0 = unlimited
+            }
+            if let Some(k) = timemachine_keep_safety {
+                cfg.timemachine_keep_safety = Some(k);
             }
             if let Some(k) = timemachine_max_files {
                 cfg.timemachine_max_files = Some(k.max(1));
@@ -337,19 +433,71 @@ pub(crate) async fn run_config(cmd: Option<ConfigCmd>) -> Result<()> {
             if let Some(b) = adaptive_effort {
                 cfg.adaptive_effort = Some(b);
             }
+            if let Some(v) = prompt_tier {
+                let v = v.trim().to_ascii_lowercase();
+                if v.is_empty() {
+                    cfg.prompt_tier = None; // back to the by-model heuristic
+                } else {
+                    if !["full", "strict"].contains(&v.as_str()) {
+                        anyhow::bail!("--prompt-tier must be one of: full, strict");
+                    }
+                    cfg.prompt_tier = Some(v);
+                }
+            }
+            if let Some(b) = eager_tools {
+                cfg.eager_tools = Some(b);
+            }
+            if let Some(b) = self_review {
+                cfg.self_review = Some(b);
+            }
+            // `sandbox.mode` only — the rest of the sandbox block (roots, pass-env, limits) stays a
+            // hand-edit, because those are lists whose meaning depends on the machine.
+            if let Some(v) = sandbox_mode {
+                let mode = v
+                    .parse::<crate::sandbox::SandboxMode>()
+                    .map_err(anyhow::Error::msg)?;
+                let mut sb = cfg.sandbox.take().unwrap_or_default();
+                sb.mode = Some(mode);
+                cfg.sandbox = Some(sb);
+            }
             if let Some(v) = disabled_toolsets {
                 cfg.disabled_toolsets = parse_toolset_list(&v);
             }
             if let Some(v) = enabled_toolsets {
                 cfg.enabled_toolsets = parse_toolset_list(&v);
             }
+            if let Some(n) = max_subagents {
+                cfg.max_parallel_subagents = (n > 0).then_some(n); // 0 ⇒ machine-derived again
+            }
+            if let Some(b) = workflow_tool {
+                cfg.workflow_tool = Some(b);
+            }
             // Per-role endpoints (`roles.*`): set any of model/base_url/api_key_ref; an empty string
             // CLEARS that field. Editing any sub-field materializes the `roles` object; clearing
             // every field of every role drops it again.
             if any_role_flag {
+                // A profile name that does not exist would route the role to nothing and only show
+                // up as a failed run much later. Refuse it here, where the typo is still on screen.
+                let known: Vec<String> = cfg
+                    .providers
+                    .iter()
+                    .flatten()
+                    .map(|p| p.name.clone())
+                    .collect();
+                for (role, provider, ..) in &role_flags {
+                    let Some(name) = provider.as_deref().map(str::trim).filter(|n| !n.is_empty())
+                    else {
+                        continue;
+                    };
+                    if !known.iter().any(|k| k == name) {
+                        anyhow::bail!(
+                            "no saved provider profile '{name}' for role {role} — see `aizen config provider list`"
+                        );
+                    }
+                }
                 let mut roles = cfg.roles.take().unwrap_or_default();
-                for (role, model, base_url, api_key_ref) in role_flags {
-                    apply_role_flags(&mut roles, role, model, base_url, api_key_ref);
+                for (role, provider, model, base_url, api_key_ref) in role_flags {
+                    apply_role_flags(&mut roles, role, provider, model, base_url, api_key_ref);
                 }
                 cfg.roles = roles.has_any().then_some(roles);
             }

--- a/src/ui/effort_ui.rs
+++ b/src/ui/effort_ui.rs
@@ -48,11 +48,18 @@ pub(crate) fn effort_turn_line(eff: Option<&str>) -> String {
     format!("{} {}", theme::faint("  effort:"), styled)
 }
 
-/// The current effort setting as a slider index: 0 = auto (auto-detect ON, no pinned tier), else the
-/// pinned tier (1=low · 2=medium · 3=high). A pinned-but-unknown effort string, or auto-off with no
-/// pin, both fall back to `auto` so the slider always opens on a valid stop.
+/// The current effort setting as a slider index: 0 = auto (auto-detect ON, no pinned tier), 1..=5
+/// the pinned tier, 6 = ultimate. A pinned-but-unknown effort string, or auto-off with no pin, both
+/// fall back to `auto` so the slider always opens on a valid stop.
+///
+/// Ultimate answers first because it is not a tier: it pins max effort every turn regardless of
+/// what `reasoning_effort` says, so opening the slider anywhere else would be showing a setting
+/// that is not the one in force.
 fn effort_slider_start() -> usize {
     let cfg = cli_config::load();
+    if cli_config::ultimate_enabled() {
+        return ULTIMATE;
+    }
     if cli_config::auto_effort_enabled() {
         return 0; // auto ON ⇒ the "auto" stop, regardless of any stale pinned value
     }
@@ -66,19 +73,38 @@ fn effort_slider_start() -> usize {
     }
 }
 
-/// Apply a slider choice to the config and persist it. `0` ⇒ auto (auto_effort=None, clear the pin);
-/// `1..=5` ⇒ pin low/medium/high/xhigh/max and turn auto off — the exact same writes as `/effort auto`
-/// and `/effort low|medium|high|xhigh|max`, so the slider and the text commands stay in lockstep.
+/// The top stop, `tui::E_TIERS`' last index. Named because it is the one stop that is a mode
+/// rather than a rung, and three places have to agree about which one it is.
+const ULTIMATE: usize = 6;
+
+/// Apply a slider choice to the config and persist it. `0` ⇒ auto (auto_effort=None, clear the
+/// pin); `1..=5` ⇒ pin low/medium/high/xhigh/max and turn auto off; `6` ⇒ ultimate. The same writes
+/// as `/effort auto`, `/effort low|…|max` and `/ultimate`, so the slider and the text commands stay
+/// in lockstep.
+///
+/// Every branch writes `ultimate`, not just the one that turns it on. Sliding down off the top stop
+/// has to turn the mode off too — otherwise the tier you just chose is picked and then silently
+/// overruled every turn by a flag nothing cleared.
 fn apply_effort_choice(idx: usize) {
     let mut cfg = cli_config::load();
     let msg = match idx {
+        ULTIMATE => {
+            cfg.ultimate = Some(true);
+            // Pinned as well as flagged: `ultimate_enabled` is what forces max at turn time, and
+            // this is what `/effort status` and the next slider open both read back.
+            cfg.reasoning_effort = Some("max".to_string());
+            cfg.auto_effort = Some(false);
+            "✦ ultimate ON — max reasoning effort every turn + prefers launching workflows for fan-out-able tasks.".to_string()
+        }
         1..=5 => {
             let tier = ["", "low", "medium", "high", "xhigh", "max"][idx];
+            cfg.ultimate = None;
             cfg.reasoning_effort = Some(tier.to_string());
             cfg.auto_effort = Some(false);
             format!("effort pinned to {tier} (auto off) — every turn now sends reasoning_effort={tier}.")
         }
         _ => {
+            cfg.ultimate = None;
             cfg.auto_effort = None; // None ⇒ auto ON (the default)
             cfg.reasoning_effort = None; // clear any stale pin so auto isn't shadowed
             "effort auto ON — each turn's effort is detected from your message (keyword + complexity).".to_string()
@@ -88,6 +114,10 @@ fn apply_effort_choice(idx: usize) {
         Ok(_) => tui::emit_line(&style(msg).color256(splash::ACCENT).to_string()),
         Err(e) => tui::emit_line(&format!("{} {e}", style("effort:").red())),
     }
+    // Recolour the retained input box, exactly as `/ultimate` does: gold while ultimate is ON,
+    // moonlight when OFF. Reads the effective state, so an `AIZEN_ULTIMATE` in the environment
+    // keeps the box gold even after the slider was dragged down from the top.
+    tui::set_ultimate(cli_config::ultimate_enabled());
 }
 
 /// The plain text status report for `/effort status` (and the off-TTY fallback of the bare `/effort`).
@@ -131,5 +161,74 @@ pub(crate) fn effort_slider_flow() {
     match tui::effort_slider(effort_slider_start()) {
         Some(idx) => apply_effort_choice(idx),
         None => tui::emit_line(&style("(effort unchanged)").dim().to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One temp home per test body, serialised against every other test that reads config.
+    fn isolated(tag: &str) -> std::sync::MutexGuard<'static, ()> {
+        let guard = crate::core::config::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let home = std::env::temp_dir().join(format!("aizen-effort-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        std::env::set_var("AIZEN_HOME", &home);
+        // The env forces ultimate on wherever it is set, which would make every assertion below
+        // pass for the wrong reason.
+        std::env::remove_var("AIZEN_ULTIMATE");
+        std::env::remove_var("AIZEN_AUTO_EFFORT");
+        guard
+    }
+
+    /// The slider's top stop is a real stop. It used to fall through to the catch-all arm, so
+    /// dragging to `ultimate` and pressing Enter turned auto-detect ON — the opposite of the label.
+    #[test]
+    fn the_top_stop_turns_ultimate_on_rather_than_auto() {
+        let _g = isolated("on");
+
+        apply_effort_choice(ULTIMATE);
+
+        let cfg = cli_config::load();
+        assert_eq!(cfg.ultimate, Some(true));
+        assert_eq!(cfg.reasoning_effort.as_deref(), Some("max"));
+        assert_eq!(cfg.auto_effort, Some(false));
+        assert!(cli_config::ultimate_enabled());
+        // And the slider reopens where it was left, which it could not do before either.
+        assert_eq!(effort_slider_start(), ULTIMATE);
+    }
+
+    /// Sliding back down has to clear the mode, not just choose a tier underneath it: ultimate
+    /// pins max every turn regardless of `reasoning_effort`, so a leftover flag would quietly
+    /// overrule the rung the user just picked.
+    #[test]
+    fn sliding_down_off_the_top_stop_turns_the_mode_off() {
+        let _g = isolated("off");
+
+        apply_effort_choice(ULTIMATE);
+        apply_effort_choice(2);
+
+        let cfg = cli_config::load();
+        assert_eq!(cfg.ultimate, None);
+        assert_eq!(cfg.reasoning_effort.as_deref(), Some("medium"));
+        assert!(!cli_config::ultimate_enabled());
+        assert_eq!(effort_slider_start(), 2);
+
+        // All the way back to auto clears the pin as well as the mode.
+        apply_effort_choice(0);
+        let cfg = cli_config::load();
+        assert_eq!(cfg.ultimate, None);
+        assert_eq!(cfg.reasoning_effort, None);
+        assert_eq!(effort_slider_start(), 0);
+    }
+
+    /// The index this module calls the top stop is the index the rail draws it at.
+    #[test]
+    fn the_named_top_stop_is_the_rails_last_one() {
+        assert_eq!(ULTIMATE, tui::E_TIERS.len() - 1);
+        assert_eq!(tui::E_TIERS[ULTIMATE], "ultimate");
     }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -3509,7 +3509,7 @@ const NOTCHES: [usize; 7] = [0, 8, 16, 24, 31, 38, 48];
 /// Stop labels, left→right. Index is the value returned by [`effort_slider`]. The last stop,
 /// `ultimate`, is not merely a hotter tier — it's the mode toggle (max effort + orchestrate-by-default),
 /// folded onto the far end of the rail so one drag reaches it.
-const E_TIERS: [&str; 7] = ["auto", "low", "medium", "high", "xhigh", "max", "ultimate"];
+pub(crate) const E_TIERS: [&str; 7] = ["auto", "low", "medium", "high", "xhigh", "max", "ultimate"];
 /// One-line gist shown under the focused stop.
 const E_DESCS: [&str; 7] = [
     "detect per-turn from your wording — keyword + complexity",


### PR DESCRIPTION
Five commits, each standalone. The through-line for three of them is **surfaces that existed but could not be reached** — a config key with no flag, a run knob only the REPL could arm, a slider stop that did the opposite of its label.

## Commits

**`fix(skills): install a named skill without going through search`**
An explicit `owner/name` went through the keyword index instead of the by-slug route.

**`fix(skills): survive a registry whose search index is down, and repos that moved`**
`search` treated the keyword index as the last word on what the registry holds — when that route answered 500, every install reported an empty catalogue, which reads as "there are no skills" rather than "the search box is broken". The catalogue is served page by page throughout, so a bounded fallback (12 pages × 100, honouring `hasMore`) now matches locally, only on the failing path, and re-raises the index's own error rather than claiming the registry is empty.

`install` also went to GitHub for the body of any search hit. A hit's coordinates are a snapshot, and repos move: `bytedance/frontend-design` is listed at a path that now 404s while the registry still serves it by slug. By-slug first, GitHub as fallback.

**`feat(cli): make the settings and the run knobs reachable without editing JSON`**
Twelve config keys were read on every run and settable by nothing — not in the wizard, so changing one meant hand-editing `cli-config.json`, around the exclusive lock and the corrupt-file backup that `save` exists to provide. Each is a flag now, and each can be **un**set (`--max-tokens 0`, empty clears, `--prompt-cache auto`).

`RoleModelConfig.provider` was the one field of four with no flag, so the routing the struct documents as preferred was the only one you could not take without editing JSON. Added for all four roles, validated against `providers[]` rather than written blind.

`aizen agent` gained `--save-session` (the non-interactive path left no transcript at all, since autosave lives in the REPL's turn) and `--effort` (per-run, persists nothing — `/effort` pins by writing config, so a front-end wanting one hard run and one cheap one had to rewrite the user's settings between them).

Fixed in passing: the "is this role still configured?" test ignored `provider` and `reasoning_effort`, so clearing a role's model silently dropped a per-role effort set by hand beside it.

**`fix(effort): /effort's top stop set auto-detect instead of ultimate`**
The rail draws seven stops; `apply_effort_choice` handled `1..=5`. Index 6 fell through to the catch-all, so dragging to `ultimate` and pressing Enter turned auto-detect **on** and cleared the pin. One of the three new tests asserts that the index this module calls the top stop is the index the rail draws it at — the drift that caused it.

**`fix(build): pick the stack link arg by target env, not target OS`**
⚠️ Worth a look: #13's stack-reserve bump is gated on `CARGO_CFG_TARGET_OS == "windows"`, but `/STACK:16777216` is `link.exe` syntax and that cfg is equally true for `-windows-gnu`, where GNU ld reads it as a filename and the link fails outright. **`main` currently does not build on the gnu toolchain.** Split by `CARGO_CFG_TARGET_ENV`.

CI could not have caught it: the matrix is `[ubuntu-latest, windows-latest, macos-latest]` with no target pinned, and windows-latest defaults to msvc, so gnu is never built. Adding a gnu job is a separate call — happy to do it if wanted.

## Type of change

- [x] Bug fix (regression test included)
- [x] New feature
- [x] Docs / comments / tests only
- [ ] Refactor (no behavior change)

## Checklist

- [x] I ran `cargo test --bin aizen` and it's **green**. — 1676 passed, 0 failed, 2 ignored, on the rebased tree
- [x] I ran `cargo fmt` and `cargo clippy` and cleared anything I introduced. — fmt clean; clippy exit 0. The 7 warnings in files touched here sit on lines this branch does not change; `ConfigCmd::Set` already had 37 fields before it, so `large_enum_variant` was firing already
- [x] I added or updated tests for my change.
- [x] My change keeps the **pure-Rust single-static-binary** posture (no new C/native deps).
- [x] I have agreed to the [CLA](../blob/main/CLA.md).

## Notes for the reviewer

- Rebased onto `a19977d`, so the build fix is verified against #13's actual tree rather than against its base.
- The skills fallback costs nothing on the healthy path: it runs only after the index errors.
- CHANGELOG entries cover the config/agent/effort work. The two skills commits are **not** in the CHANGELOG — say the word and I'll add them.