### PR TITLE
chore(governance): adopt a dev integration branch and write the process down

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Who must review what. With "Require review from Code Owners" enabled on `main` and `dev`, a pull
+# request cannot merge until the owner listed here has approved it — the catch-all covers the whole
+# tree, and the entries below exist to make ownership of the expensive-to-get-wrong areas explicit
+# rather than merely inherited.
+
+*                            @dawnofcd
+
+# Licensing and governance: changing these changes what every downstream user is allowed to do.
+# `LICENSE` is a byte-exact copy of Apache-2.0 — reformatting it breaks license detection.
+/LICENSE                     @dawnofcd
+/NOTICE                      @dawnofcd
+/CLA.md                      @dawnofcd
+
+# CI, release automation and the branch rules themselves.
+/.github/                    @dawnofcd
+
+# The safety boundary: every model-influenced process is spawned through here.
+/src/sandbox/                @dawnofcd
+
+# Self-update points users at a release channel — a wrong repo slug ships them someone else's binary.
+/src/features/update.rs      @dawnofcd
+/install.ps1                 @dawnofcd
+/install.sh                  @dawnofcd

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,13 @@
 
 Closes #
 
+## Base branch
+
+<!-- Feature and fix PRs target `dev`. Only a release/* or hotfix/* branch targets `main`.
+     See docs/BRANCHING.md. -->
+
+- [ ] This PR targets **dev** (or it is a release/hotfix PR targeting `main`).
+
 ## Type of change
 
 - [ ] Bug fix (regression test included)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: ci
 
-# Build + test on every push to main and every pull request, so contributors get fast feedback and
-# a PR can't merge red. Pure-Rust single static binary — no C toolchain needed. Uses the built-in
-# GITHUB_TOKEN only; runs on forks' PRs too (pull_request, not pull_request_target — no secrets
-# exposed to untrusted code).
+# Build + test on every push to main or dev and on every pull request, so contributors get fast
+# feedback and a PR can't merge red. Pure-Rust single static binary — no C toolchain needed. Uses
+# the built-in GITHUB_TOKEN only; runs on forks' PRs too (pull_request, not pull_request_target —
+# no secrets exposed to untrusted code).
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,13 @@ Requirements:
 
 ## Making a change
 
-1. **Fork** the repo and create a branch off `main` (`git checkout -b my-fix`).
+1. **Fork** the repo and create a branch off `dev`, the integration branch (`git switch -c my-fix public/dev`). `main` is the release line and only accepts release/hotfix PRs — see [docs/BRANCHING.md](docs/BRANCHING.md).
 2. Make your change. Match the surrounding code — naming, comment density, error handling.
 3. **Add or update tests.** New behavior needs a test; a bug fix needs a test that would have caught it.
 4. Run `cargo test --bin aizen` and make sure it's **green**.
 5. Run `cargo fmt` and `cargo clippy` and clear anything you introduced.
 6. Commit with a clear message (imperative mood: "fix scrollbar drift", not "fixed stuff").
-7. Push and open a PR against `aizen-stack/aizen:main`. Fill in the PR template.
+7. Push and open a PR against `aizen-stack/aizen:dev`. Fill in the PR template.
 
 ## What gets merged
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,104 @@
+# Branching and release process
+
+The rules a change follows from a working tree to a published binary. They are enforced by GitHub
+branch protection and CI, not by memory — if something here is only a convention, it says so.
+
+## The two remotes (read this first)
+
+| Remote | URL | Role |
+|---|---|---|
+| `public` | `github.com/aizen-stack/aizen` | **the live line.** `main`, `dev`, every PR, every release |
+| `origin` | `github.com/dawnofcd/Aizen_agent` (private) | historical private mirror — **divergent history** |
+
+`origin/main` and `public/main` do not share an ancestor any more. Never merge one into the other:
+a cross-merge would replay years of unrelated history into the live line. All work described below
+happens on `public`.
+
+## Branches
+
+| Branch | Cut from | Merges into | Protected |
+|---|---|---|---|
+| `main` | — | — | yes — release line, always tagged and shippable |
+| `dev` | `main` | `main` (via a release branch) | yes — integration line, always green |
+| `feat/*`, `fix/*`, `chore/*`, `docs/*`, `refactor/*` | `dev` | `dev` | no |
+| `release/vX.Y.Z` | `dev` | `main` | no |
+| `hotfix/vX.Y.Z` | `main` | `main` **and** `dev` | no |
+
+`main` only ever moves through a release or a hotfix PR. Day-to-day work never targets it.
+
+## Everyday flow
+
+```bash
+git fetch public
+git switch -c fix/short-description public/dev     # always cut from dev, never from a stale local
+# … work, commit …
+cargo fmt && cargo clippy && cargo test --bin aizen   # all three green BEFORE you push
+git push -u public fix/short-description
+gh pr create --base dev --fill                     # base is dev — a PR into main will be rejected
+```
+
+A PR merges when: CI is green on every OS in the matrix, the CLA check passes, and the code owner
+has approved. Squash-merge is the default so `dev` reads as one commit per change; a merge commit is
+fine for a branch whose individual commits are worth keeping.
+
+## Release
+
+```bash
+git switch -c release/v0.7.0 public/dev
+# bump the version in Cargo.toml, update the changelog, no other change
+git push -u public release/v0.7.0
+gh pr create --base main --title "release: 0.7.0 — <the headline>"
+# merge once CI is green, then tag the MERGE COMMIT on main:
+git fetch public && git tag v0.7.0 public/main && git push public v0.7.0
+git switch dev && git merge --ff-only public/main && git push public dev   # dev absorbs the bump
+```
+
+Tag from `main` after the merge, never from the release branch. `release.yml` fires on `v*` and
+**only builds** — it does not run the test suite, so the tag must sit on a commit `ci.yml` already
+proved green. A tag placed outside `main` has never been tested by CI (this happened for 0.6.5).
+
+After publishing, check that the landing page and the install scripts point at the new version —
+they are a separate deploy and drift on their own.
+
+## Hotfix
+
+A production break that cannot wait for the next release:
+
+```bash
+git switch -c hotfix/v0.7.1 public/main
+# the smallest possible fix + its regression test
+gh pr create --base main
+```
+
+After it merges and is tagged, open a second PR merging `main` back into `dev`, or the fix is lost
+at the next release.
+
+## What protection enforces
+
+On both `main` and `dev`:
+
+- pull request required — no direct pushes, including for the maintainer
+- CI (`build + test` on ubuntu, macos and windows) must pass
+- CLA check must pass
+- code-owner approval required (see [CODEOWNERS](../.github/CODEOWNERS))
+- branch must be up to date with its base before merging
+- force-push and deletion blocked
+- conversations must be resolved before merge
+
+The `cla-signatures` branch stores the signature ledger and **must stay unprotected** — the CLA bot
+writes to it directly and cannot open a PR against a protected branch.
+
+## Local gates (not enforceable by GitHub)
+
+CI runs the same commands, but finding it locally is minutes instead of a red PR:
+
+```bash
+cargo fmt
+cargo clippy
+cargo test --bin aizen        # slow on Windows — run it in the background, not a 120 s shell call
+cargo build --release --bin aizen
+```
+
+The hard constraints a reviewer will reject a PR over are in [CLAUDE.md](../CLAUDE.md): pure Rust,
+one static binary, no C/native dependency, rustls only, and no casual regression of startup time or
+binary size.


### PR DESCRIPTION
## What does this PR do?

Moves the project onto a `feature -> dev -> release/* -> main` flow so `main` only ever advances
through a reviewed release or hotfix, and documents the rules instead of leaving them as folklore.

- `docs/BRANCHING.md` — branch model, everyday flow, release and hotfix procedures, what branch
  protection enforces, and the two-remote rule (`aizen-stack/aizen` is the live line; the private
  `Aizen_agent` remote has a divergent history and must never be cross-merged)
- `.github/CODEOWNERS` — review ownership, explicit for licensing, CI, the sandbox boundary and the
  self-update channel
- `ci.yml` now also runs on pushes to `dev` — an integration branch nothing verifies is not one
- `CONTRIBUTING.md` told contributors to branch off `main` and open PRs against `main`; both now
  say `dev`
- the PR template asks for the base branch up front — the most common slip in a GitFlow repo

## Base branch

- [x] This PR targets **dev**.

## Type of change

- [x] Docs / comments / tests only (plus one CI trigger line)

## Checklist

- [x] No source change, so the build is unaffected; `ci.yml` is the only workflow touched.
- [x] Keeps the pure-Rust single-static-binary posture (no code touched).

## Notes for the reviewer

`cla-signatures` must stay UNPROTECTED when protection is applied — the CLA bot writes the ledger
there directly and cannot open a PR against a protected branch.