### PR TITLE
test(config): stop the auto-copy test from racing every home-sandboxed test

### DIFF
--- a/src/core/cli_config.rs
+++ b/src/core/cli_config.rs
@@ -1629,12 +1629,21 @@ mod tests {
 
     #[test]
     fn auto_copy_defaults_on_and_honours_field_and_env() {
+        // `AIZEN_HOME` is process-global, so every test that repoints it takes this lock — without
+        // it this test and any concurrently running home-sandboxed test clobber each other's home
+        // and one of the two fails, whichever loses the race. `EnvGuard` restores `AIZEN_AUTO_COPY`
+        // so an ambient value on the developer's machine survives the run.
+        let _g = crate::core::config::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _restore = crate::core::config::EnvGuard::unset(["AIZEN_AUTO_COPY"]);
         // Isolate from the developer's real ~/.aizen and any ambient AIZEN_AUTO_COPY.
         let dir = std::env::temp_dir().join(format!("aizen-auto-copy-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        std::env::set_var("AIZEN_HOME", &dir);
-        std::env::remove_var("AIZEN_AUTO_COPY");
+        // Guarded, not a raw set_var: this directory is deleted at the end of the test, so leaving
+        // AIZEN_HOME pointing at it would hand every later test a home that does not exist.
+        let _home = crate::core::config::EnvGuard::set([("AIZEN_HOME", &dir)]);
 
         // Never touched → ON (browser-like default the feature shipped with).
         assert!(auto_copy_enabled());


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky test that landed with #17 and will otherwise block merges at random now that CI is a
required check on `main` and `dev`.

`auto_copy_defaults_on_and_honours_field_and_env` repointed the process-global `AIZEN_HOME` with a
raw `set_var`, took none of the `TEST_HOME_LOCK` that every other home-mutating test coordinates on,
never restored the variable, and then deleted the directory it pointed at.

Two consecutive full-suite runs failed on two **different** tests because of it:

| run | failing test | why |
|---|---|---|
| 1 | `agents::tests::index_lists_enabled_subset_only` | its sandbox home was pulled out from under it |
| 2 | `core::cli_config::tests::auto_copy_defaults_on_and_honours_field_and_env` | a sibling's `EnvGuard` restored the variable mid-assertion |

Each passes in isolation — the signature of a shared-environment race, not a defect in either test.

The fix follows what the other nine tests in the same file already do: take `TEST_HOME_LOCK`, and
guard the variables with `EnvGuard` so both `AIZEN_HOME` and an ambient `AIZEN_AUTO_COPY` are
restored on drop instead of leaking a deleted directory into whatever runs next.

## Base branch

- [x] This PR targets **dev**.

## Type of change

- [x] Bug fix (the flake is the regression; the fix is the guard)

## Checklist

- [x] `cargo test --bin aizen` — **four consecutive full-suite runs green** (1687 passed each).
- [x] `cargo fmt` clean.
- [x] Test-only change; no behavior change and no new dependency.

## Notes for the reviewer

Worth a quick sweep for other raw `set_var("AIZEN_HOME", …)` calls outside the lock — this one was
found by accident while validating an unrelated branch, so there may be siblings.