### PR TITLE
perf(agent): cut LLM round-trips on the read, done-gate and re-read paths

### DIFF
--- a/src/agent/builtin.rs
+++ b/src/agent/builtin.rs
@@ -1673,33 +1673,27 @@ impl FileRead {
         Self { root }
     }
 }
-impl Tool for FileRead {
-    fn name(&self) -> &str {
-        "file_read"
-    }
-    fn description(&self) -> &str {
-        "Read a file (optionally a 1-based line range). Use before editing. Set number:true to \
-         prefix each line with its 1-based number (`N|line`) for orientation — leave it off (the \
-         default) when you'll feed the text back into file_edit's old_string. A relative path \
-         resolves under the working directory; an absolute path or `../` reads elsewhere too. \
-         To learn a file's shape use lsp_document_symbols, and to read ONE named item use \
-         read_symbol — both are far cheaper than dumping the whole file here. Read-only."
-    }
-    fn parameters(&self) -> Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "path": {"type": "string"},
-                "start": {"type": "integer", "description": "1-based first line (optional)"},
-                "end": {"type": "integer", "description": "1-based last line (optional)"},
-                "number": {"type": "boolean", "description": "prefix each line with `N|` (default false)"}
-            },
-            "required": ["path"],
-            "additionalProperties": false
-        })
-    }
-    fn execute(&self, args: &Value) -> Result<String> {
-        let path = str_arg(args, "path")?;
+/// Cap on entries honoured in one `files:[…]` batch read. Enough to cover every hit of a search
+/// turn in one call; anything past it is reported (never silently dropped) so the model knows to
+/// call again.
+const MULTI_READ_MAX_FILES: usize = 8;
+
+impl FileRead {
+    /// One file (or slice of it) — the shared body behind both the single `path` form and each
+    /// `files:[…]` entry. `max_lines`/`max_bytes` bound a WHOLE-file read (a batch splits the
+    /// single-call budget across its entries); `symbol_hint` gates the LSP advisory, which only
+    /// the single form emits (once per batch would be spam).
+    #[allow(clippy::too_many_arguments)]
+    fn read_one(
+        &self,
+        path: &str,
+        start: Option<u64>,
+        end: Option<u64>,
+        number: bool,
+        max_lines: usize,
+        max_bytes: usize,
+        symbol_hint: bool,
+    ) -> Result<String> {
         let resolved = confine(&self.root, path, true)?;
         let content = std::fs::read_to_string(&resolved)
             .with_context(|| format!("reading {}", resolved.display()))?;
@@ -1711,25 +1705,21 @@ impl Tool for FileRead {
             &resolved,
             &crate::core::persist::FileFingerprint::for_bytes(content.as_bytes()),
         );
-        let start = args.get("start").and_then(|v| v.as_u64());
-        let end = args.get("end").and_then(|v| v.as_u64());
-        let number = args
-            .get("number")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
         // The whole file — verbatim under budget (the common case; keeps old_string round-trips
         // byte-exact), or a clearly-marked head+tail preview when it's pathologically large.
         if start.is_none() && end.is_none() && !number {
-            let view = budget_view(&content, path, FILE_READ_MAX_LINES, FILE_READ_MAX_BYTES);
+            let view = budget_view(&content, path, max_lines, max_bytes);
             // Retrieval-first nudge (mức 2): a long whole-file SOURCE read the model likely needs
             // one item from. Advisory — the full `view` still follows — and only when the symbol
             // tools it names are actually available (`is_code` + LSP on). Prepended so the model
             // sees it before committing to re-reading the same file next turn.
-            let is_code = crate::agent::lsp::discovery::server_for_path(&resolved).is_some();
-            let lsp_on = crate::agent::lsp::LSP.is_enabled();
-            let line_count = content.lines().count();
-            if let Some(hint) = whole_file_symbol_hint(is_code, lsp_on, line_count) {
-                return Ok(format!("{hint}\n{view}"));
+            if symbol_hint {
+                let is_code = crate::agent::lsp::discovery::server_for_path(&resolved).is_some();
+                let lsp_on = crate::agent::lsp::LSP.is_enabled();
+                let line_count = content.lines().count();
+                if let Some(hint) = whole_file_symbol_hint(is_code, lsp_on, line_count) {
+                    return Ok(format!("{hint}\n{view}"));
+                }
             }
             return Ok(view);
         }
@@ -1750,6 +1740,112 @@ impl Tool for FileRead {
         } else {
             Ok(lines[s - 1..e].join("\n"))
         }
+    }
+
+    /// The `files:[…]` batch form: N files/slices in ONE call — one round-trip instead of a
+    /// read-per-turn dribble. Per-entry errors are reported INLINE (a missing file must not void
+    /// the seven good reads next to it), and whole-file entries split the single-call budget so a
+    /// batch cannot admit N× the bytes one call may return.
+    fn read_many(&self, list: &[Value], args: &Value) -> Result<String> {
+        if list.is_empty() {
+            bail!("files[] is empty — pass at least one {{path,start,end}} entry, or use `path`");
+        }
+        let number = args
+            .get("number")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let shown = &list[..list.len().min(MULTI_READ_MAX_FILES)];
+        let per_lines = (FILE_READ_MAX_LINES / shown.len()).max(200);
+        let per_bytes = (FILE_READ_MAX_BYTES / shown.len()).max(20_000);
+        let mut out: Vec<String> = Vec::with_capacity(shown.len() + 1);
+        for entry in shown {
+            let Some(path) = entry.get("path").and_then(|v| v.as_str()) else {
+                out.push("── (entry missing `path`) ──".to_string());
+                continue;
+            };
+            let start = entry.get("start").and_then(|v| v.as_u64());
+            let end = entry.get("end").and_then(|v| v.as_u64());
+            let header = match (start, end) {
+                (None, None) => format!("── {path} ──"),
+                (s, e) => format!(
+                    "── {path}:{}-{} ──",
+                    s.map_or("1".to_string(), |v| v.to_string()),
+                    e.map_or("end".to_string(), |v| v.to_string()),
+                ),
+            };
+            match self.read_one(path, start, end, number, per_lines, per_bytes, false) {
+                Ok(body) => out.push(format!("{header}\n{body}")),
+                Err(err) => out.push(format!("{header}\nerror: {err:#}")),
+            }
+        }
+        if list.len() > MULTI_READ_MAX_FILES {
+            out.push(format!(
+                "…[{} more file(s) not read — {MULTI_READ_MAX_FILES} per call max; call again for the rest]",
+                list.len() - MULTI_READ_MAX_FILES
+            ));
+        }
+        Ok(out.join("\n"))
+    }
+}
+
+impl Tool for FileRead {
+    fn name(&self) -> &str {
+        "file_read"
+    }
+    fn description(&self) -> &str {
+        "Read a file (optionally a 1-based start/end line range), or SEVERAL files in ONE call via \
+         files:[{path,start,end},…] — batch independent reads instead of one per turn. Use before \
+         editing. Set number:true to prefix each line with its 1-based number (`N|line`) — leave it \
+         off (the default) when you'll feed the text back into file_edit's old_string. A relative \
+         path resolves under the working directory; absolute or `../` paths read elsewhere too. For \
+         ONE named item prefer lsp_document_symbols + read_symbol over dumping the file. Read-only."
+    }
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "start": {"type": "integer", "description": "1-based first line (optional)"},
+                "end": {"type": "integer", "description": "1-based last line (optional)"},
+                "number": {"type": "boolean", "description": "prefix each line with `N|` (default false)"},
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "start": {"type": "integer"},
+                            "end": {"type": "integer"}
+                        },
+                        "required": ["path"]
+                    },
+                    "description": "batch form: several files/slices in one call (max 8); overrides path"
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        })
+    }
+    fn execute(&self, args: &Value) -> Result<String> {
+        if let Some(list) = args.get("files").and_then(|v| v.as_array()) {
+            return self.read_many(list, args);
+        }
+        let path = str_arg(args, "path")?;
+        let start = args.get("start").and_then(|v| v.as_u64());
+        let end = args.get("end").and_then(|v| v.as_u64());
+        let number = args
+            .get("number")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        self.read_one(
+            path,
+            start,
+            end,
+            number,
+            FILE_READ_MAX_LINES,
+            FILE_READ_MAX_BYTES,
+            true,
+        )
     }
 }
 
@@ -3657,6 +3753,53 @@ mod tests {
         assert!(whole_file_symbol_hint(false, true, 800).is_none());
         assert!(whole_file_symbol_hint(true, false, 800).is_none());
         assert!(whole_file_symbol_hint(true, true, FILE_READ_MAX_LINES + 1).is_none());
+    }
+
+    #[test]
+    fn file_read_files_batch_reads_slices_and_reports_per_file_errors() {
+        let root = temp_root("multi-read");
+        std::fs::write(root.join("a.txt"), "alpha-1\nalpha-2\nalpha-3\n").unwrap();
+        std::fs::write(root.join("b.txt"), "beta-1\nbeta-2\nbeta-3\nbeta-4\n").unwrap();
+        let t = FileRead::new(root);
+        let out = t
+            .execute(&serde_json::json!({"files": [
+                {"path": "a.txt"},
+                {"path": "b.txt", "start": 2, "end": 3},
+                {"path": "missing.txt"}
+            ]}))
+            .unwrap();
+        // Whole file, a range slice, and an inline per-entry error — all in ONE result.
+        assert!(out.contains("── a.txt ──"), "whole-file header: {out}");
+        assert!(out.contains("alpha-3"), "whole-file body: {out}");
+        assert!(out.contains("── b.txt:2-3 ──"), "range header: {out}");
+        assert!(out.contains("beta-2\nbeta-3"), "range body: {out}");
+        assert!(!out.contains("beta-4"), "range must exclude line 4: {out}");
+        assert!(
+            out.contains("── missing.txt ──\nerror:"),
+            "a missing file reports inline instead of voiding the batch: {out}"
+        );
+    }
+
+    #[test]
+    fn file_read_files_batch_caps_entries_and_says_so() {
+        let root = temp_root("multi-read-cap");
+        for i in 0..10 {
+            std::fs::write(root.join(format!("f{i}.txt")), format!("body-{i}\n")).unwrap();
+        }
+        let files: Vec<serde_json::Value> = (0..10)
+            .map(|i| serde_json::json!({"path": format!("f{i}.txt")}))
+            .collect();
+        let t = FileRead::new(root);
+        let out = t.execute(&serde_json::json!({ "files": files })).unwrap();
+        assert!(out.contains("body-7"), "8th entry still read: {out}");
+        assert!(
+            !out.contains("body-8"),
+            "9th entry must be dropped, not read: {out}"
+        );
+        assert!(
+            out.contains("2 more file(s) not read"),
+            "the drop is REPORTED, never silent: {out}"
+        );
     }
 
     #[test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -978,6 +978,16 @@ where
     let mut hill_climb_reframed = false;
     let mut last_hill_climb_reminder = 0usize;
     let mut iter = 0usize;
+    // Identical-re-read short-circuit: sig(file_read args) → what that call answered last time.
+    // Cleared whenever history is rebuilt (compaction / emergency shrink) — the msg_index leg of
+    // the proof dies with the rebuild. Eviction blanks bodies IN PLACE, which the byte-level
+    // intact-check catches per entry, so no clear is needed there.
+    let mut read_cache: std::collections::HashMap<String, ReadCacheEntry> =
+        std::collections::HashMap::new();
+    // Batch-coach streak (see NUDGE_BATCH): consecutive turns whose ONLY call was one read-only
+    // retrieval. One-shot latch per run.
+    let mut single_read_streak = 0usize;
+    let mut batch_nudged = false;
     // GOAL MODE bypasses the iteration cap entirely: `/goal` promises to run until the goal is
     // genuinely finished, so the only exits are Esc (→ Cancelled, via `cancel::race`) or a verified
     // completion (→ Done, via the goal gate + verify gate). Ordinary turns keep `iter < cap`.
@@ -1223,6 +1233,7 @@ where
                             budget_band_shown = None; // …and the running budget signal (P-ctx1)
                             real_anchor = None; // spliced history invalidates the anchor
                             stall.forget_successes(); // summarized-away results must not mark a re-read as stale
+                            read_cache.clear(); // rebuilt indices — the short-circuit proof is void
                             est_now = estimate_tokens(messages) + schema_overhead;
                             if !cfg.quiet {
                                 let line =
@@ -1705,6 +1716,19 @@ where
         // CLASSIFY: the structured tool_calls array is the source of truth (a gateway may
         // emit finish_reason="stop"/"end_turn" alongside tool calls — ignore it here).
         if turn.tool_calls.is_empty() {
+            // MERGED DONE-GATE CASCADE: each gate below APPENDS its demand to `demands` instead of
+            // looping back immediately. One combined round-trip then carries every demand that
+            // fired — the old shape burned one full LLM iteration PER gate (verify → self-review →
+            // todo-poke → confidence could cost 4 sequential round-trips for one "done" claim; the
+            // model can fix all four in one pass). Per-gate budgets/latches are consumed exactly as
+            // before, so the total-work bound is unchanged — only the round-trip count shrinks.
+            // The goal and steering gates stay EXCLUSIVE (evaluated only when nothing else fired):
+            // the goal gate's `take_pending` drain must only happen at a real Done decision, and a
+            // steer left in the mailbox is picked up by the top-of-loop drain for free anyway.
+            let mut demands: Vec<String> = Vec::new();
+            // Set when THIS round's verify ran and failed — self-review must not spend its
+            // once-per-run oracle call reviewing code that is known-broken.
+            let mut verify_failed_now = false;
             // VERIFY/REPAIR GATE (F2 + W8): after an editing run, run a fast typecheck before Done.
             // On failure, record the premature "done", inject the errors, and loop back for a fix.
             // The gate RE-FIRES on EVERY "done" claim until it PASSES or the attempt budget
@@ -1772,6 +1796,7 @@ where
                     };
                     if !gate_passed {
                         verify_attempts += 1;
+                        verify_failed_now = true;
                         // GOAL MODE: a failed verify invalidates any completion claim the model made
                         // this turn — clear it so the stale claim can't leak through the goal gate to
                         // Done after the model fixes the errors. The `goal_complete` ack already tells
@@ -1781,17 +1806,6 @@ where
                         if cfg.goal.is_some() {
                             goal::clear();
                         }
-                        // Record the premature "done" before the user gate-failure message.
-                        // Normalize content to "" (never null): an assistant turn with neither
-                        // content nor tool_calls is malformed (400) on strict gateways.
-                        messages.push(Message {
-                            role: "assistant".to_string(),
-                            content: Some(turn.content.clone().unwrap_or_default()),
-                            tool_calls: Vec::new(),
-                            tool_call_id: None,
-                            images: Vec::new(),
-                            cache_control: None,
-                        });
                         // Once a phase has spent past half its repair budget, offer the rewind as an
                         // explicit escape hatch: patching further is often more costly than dropping
                         // back to the last clean phase mark and re-approaching. Reuses the existing
@@ -1804,34 +1818,38 @@ where
                                 failure_msg.push_str(&hint);
                             }
                         }
-                        messages.push(Message::user(failure_msg));
-                        iter += 1;
-                        continue;
-                    }
-                    // PASSED: latch it so a subsequent no-edit "done" doesn't needlessly re-run the
-                    // gate (a fresh successful edit clears the latch → new work is re-verified).
-                    verify_passed = true;
-                    // A clean verify is the OTHER phase boundary (decision: todo-close AND
-                    // verify-pass both mark phases). This catches the no-todo run — the model edited
-                    // and finished without ever flipping a todo, so `phase_boundary_crossed` never
-                    // fired. Stamp the still-uncheckpointed edits ONCE here as a verified phase.
-                    // Gated on `made_edits_in_phase` so a no-edit "done" (latch already clean) stamps
-                    // nothing; `save` dedups a zero-diff tree so it's free when the last todo boundary
-                    // already captured this exact tree.
-                    if cfg.checkpoint_each_edit && made_edits_in_phase {
-                        phase_counter += 1;
-                        stamp_phase_checkpoint(
-                            cfg.quiet,
-                            &format!("phase {phase_counter} verified"),
-                        );
-                        made_edits_in_phase = false;
-                        phase_todos_before = crate::agent::todo::snapshot();
+                        demands.push(failure_msg);
+                    } else {
+                        // PASSED: latch it so a subsequent no-edit "done" doesn't needlessly re-run
+                        // the gate (a fresh successful edit clears the latch → new work is
+                        // re-verified).
+                        verify_passed = true;
+                        // A clean verify is the OTHER phase boundary (decision: todo-close AND
+                        // verify-pass both mark phases). This catches the no-todo run — the model
+                        // edited and finished without ever flipping a todo, so
+                        // `phase_boundary_crossed` never fired. Stamp the still-uncheckpointed edits
+                        // ONCE here as a verified phase. Gated on `made_edits_in_phase` so a no-edit
+                        // "done" (latch already clean) stamps nothing; `save` dedups a zero-diff
+                        // tree so it's free when the last todo boundary already captured this tree.
+                        if cfg.checkpoint_each_edit && made_edits_in_phase {
+                            phase_counter += 1;
+                            stamp_phase_checkpoint(
+                                cfg.quiet,
+                                &format!("phase {phase_counter} verified"),
+                            );
+                            made_edits_in_phase = false;
+                            phase_todos_before = crate::agent::todo::snapshot();
+                        }
                     }
                 }
             }
+            // Exhausted budget with no pass → end the run honestly. `!verify_failed_now` keeps the
+            // round that SPENT the last attempt on its repair turn (the old `continue` did this by
+            // construction): only the NEXT tool-free claim, with nothing left to spend, returns.
             if cfg.enable_verify_gate
                 && made_any_edits
                 && !verify_passed
+                && !verify_failed_now
                 && verify_attempts >= cfg.max_verify_attempts
             {
                 if let Some(t) = &turn.content {
@@ -1850,7 +1868,9 @@ where
             // mode (roles.oracle configured → closure supplied) has a stronger model review the
             // `git diff` — its findings come back as a fix-or-rebut turn; an LGTM costs nothing
             // extra. Nudge mode makes THIS model re-read its own diff.
-            if cfg.enable_self_review && made_any_edits && !self_review_done {
+            // Skipped (latch UNSPENT) when this round's verify failed: the once-per-run oracle call
+            // must review code that typechecks, not the broken tree the verify demand is about.
+            if cfg.enable_self_review && made_any_edits && !self_review_done && !verify_failed_now {
                 self_review_done = true;
                 match &oracle {
                     // ORACLE MODE: the verify step gates Done. A review with a [BLOCKING] finding
@@ -1860,44 +1880,23 @@ where
                     Some(o) => {
                         if let Some(review) = oracle_review(o, &review_request).await {
                             if review.blocking {
-                                // Record the premature "done" so the review turn reads coherently,
-                                // then hand back a fix-or-rebut turn (the verify step gates Done).
-                                if let Some(t) = &turn.content {
-                                    if !t.trim().is_empty() {
-                                        messages.push(Message::assistant(t.clone()));
-                                    }
-                                }
-                                messages.push(Message::user(format!(
+                                demands.push(format!(
                                     "[self-review]\n{}\n\nFix each [BLOCKING] item above, or state briefly why it does not apply — then give your final answer. [ADVISORY] items are optional.",
                                     review.findings
-                                )));
-                                iter += 1;
-                                continue;
-                            }
-                            // Advisory-only: surface the notes ONCE as a trace (they don't gate
-                            // Done — the model isn't forced to churn on style), then finish this
-                            // turn. Falls through to the shared Done return below, which records the
-                            // final assistant text exactly once (no duplicate).
-                            if !cfg.quiet {
+                                ));
+                            } else if !cfg.quiet {
+                                // Advisory-only: surface the notes ONCE as a trace (they don't gate
+                                // Done — the model isn't forced to churn on style).
                                 emit_trace(&format!(
                                     "  └ self-review: advisory only (no blocking issue)\n{}",
                                     review.findings
                                 ));
                             }
                         }
-                        // else: LGTM / no diff → fall through to Done, no extra turn.
+                        // else: LGTM / no diff → no demand, no extra turn.
                     }
-                    // NUDGE MODE (no oracle): the model re-reads its own diff. One turn, always.
-                    None => {
-                        if let Some(t) = &turn.content {
-                            if !t.trim().is_empty() {
-                                messages.push(Message::assistant(t.clone()));
-                            }
-                        }
-                        messages.push(Message::user(SELF_REVIEW_NUDGE.to_string()));
-                        iter += 1;
-                        continue;
-                    }
+                    // NUDGE MODE (no oracle): the model re-reads its own diff. One demand, always.
+                    None => demands.push(SELF_REVIEW_NUDGE.to_string()),
                 }
             }
 
@@ -1921,28 +1920,18 @@ where
                             eprintln!("{line}");
                         }
                     }
-                    messages.push(Message {
-                        role: "assistant".to_string(),
-                        content: Some(turn.content.clone().unwrap_or_default()),
-                        tool_calls: Vec::new(),
-                        tool_call_id: None,
-                        images: Vec::new(),
-                        cache_control: None,
-                    });
-                    messages.push(Message::user(format!(
+                    demands.push(format!(
                         "{TODO_POKE_PREFIX} Session todos are still incomplete — you may not finish yet.\n\n\
                          Incomplete:\n{summary}\n\n\
                          Either (a) finish the remaining items and verify, or (b) mark items done only \
                          if genuinely complete, or (c) clear the todo list to abandon the plan — then stop.\n\
                          Attempt {todo_poke_attempts}/{}.",
                         cfg.max_todo_poke_attempts
-                    )));
-                    iter += 1;
-                    continue;
+                    ));
                 }
             }
 
-            // P0.2 CONFIDENCE GATE: Done + large confidence jump → one-shot re-check turn.
+            // P0.2 CONFIDENCE GATE: Done + large confidence jump → one-shot re-check demand.
             if cfg.enable_confidence_gate && confidence_gate_armed && !confidence_gate_cleared {
                 confidence_gate_cleared = true;
                 if !cfg.quiet {
@@ -1953,6 +1942,21 @@ where
                         eprintln!("{line}");
                     }
                 }
+                demands.push(format!(
+                    "{CONFIDENCE_GATE_PREFIX} You marked todo(s) done with a large confidence jump \
+                     without stepwise evidence.\n\n\
+                     Before finishing: re-run the relevant check (tests / verify / metric). \
+                     If checks pass, keep Done. If not, reopen the todo and fix.\n\
+                     This gate fires once per run."
+                ));
+            }
+
+            // FLUSH the merged cascade: every demand that fired above rides ONE round-trip. The
+            // premature assistant text is recorded once (content normalized to "" — an assistant
+            // turn with neither content nor tool_calls is malformed (400) on strict gateways), then
+            // a single user message carries all demands. With one demand the message is byte-equal
+            // to what the old per-gate loop sent.
+            if !demands.is_empty() {
                 messages.push(Message {
                     role: "assistant".to_string(),
                     content: Some(turn.content.clone().unwrap_or_default()),
@@ -1961,13 +1965,16 @@ where
                     images: Vec::new(),
                     cache_control: None,
                 });
-                messages.push(Message::user(format!(
-                    "{CONFIDENCE_GATE_PREFIX} You marked todo(s) done with a large confidence jump \
-                     without stepwise evidence.\n\n\
-                     Before finishing: re-run the relevant check (tests / verify / metric). \
-                     If checks pass, keep Done. If not, reopen the todo and fix.\n\
-                     This gate fires once per run."
-                )));
+                let combined = if demands.len() == 1 {
+                    demands.pop().expect("non-empty")
+                } else {
+                    format!(
+                        "Multiple checks fired on your \"done\" claim — address ALL of them in this \
+                         pass:\n\n{}",
+                        demands.join("\n\n---\n\n")
+                    )
+                };
+                messages.push(Message::user(combined));
                 iter += 1;
                 continue;
             }
@@ -2157,7 +2164,46 @@ where
         // with approval on THIS future. Eager starts from the streaming path are adopted by
         // position. Results land in ORIGINAL call order. (A DISCARDED turn — divergence/error —
         // simply drops its eager handles: detached, read-only, harmless.)
-        let eager = std::mem::take(&mut turn.eager);
+        let mut eager = std::mem::take(&mut turn.eager);
+        // IDENTICAL-RE-READ SHORT-CIRCUIT: a `file_read` whose canonical args exactly match an
+        // earlier call this run, whose file bytes are unchanged, and whose earlier result is still
+        // verbatim in history would return byte-identical content the model already has. Answer it
+        // with a one-line pointer instead — injected through the eager-adoption path so traces,
+        // ordering and cancellation stay uniform. (Measured sessions: 30% of tool calls re-hit a
+        // target already hit; the byte-identical subset is pure history bloat.) A real eager start
+        // for the same slot wins — its body already ran and its result is at least as good.
+        for (k, tc) in calls.iter().enumerate() {
+            if tc.function.name != "file_read" || eager.iter().any(|(i, _)| *i == k) {
+                continue;
+            }
+            let Some(entry) = read_cache.get(&canonical_args(&tc.function.arguments)) else {
+                continue;
+            };
+            let intact = messages.get(entry.msg_index).is_some_and(|m| {
+                m.role == "tool"
+                    && m.tool_call_id.as_deref() == Some(entry.call_id.as_str())
+                    && m.content.as_deref().is_some_and(|c| {
+                        c.chars().count() == entry.result_chars
+                            && c.starts_with(&entry.result_prefix)
+                    })
+            });
+            if !intact {
+                continue;
+            }
+            let unchanged = std::fs::read(&entry.path)
+                .map(|b| crate::core::persist::FileFingerprint::for_bytes(&b) == entry.fingerprint)
+                .unwrap_or(false);
+            if !unchanged {
+                continue;
+            }
+            let canned = format!(
+                "[unchanged] {} — identical to your earlier file_read this run; that result is \
+                 still in context above and the file has not changed since. Use what you already \
+                 have, or pass a different start/end for another slice.",
+                entry.path.display()
+            );
+            eager.push((k, tokio::task::spawn(async move { canned })));
+        }
         crate::core::recovery::set_phase(crate::core::recovery::RecoveryPhase::ExecutingTools);
         let results = execute_calls(
             registry,
@@ -2229,6 +2275,95 @@ where
             }
             // Track the latest list so the next boundary is measured against it, moved or not.
             phase_todos_before = phase_todos_after;
+        }
+
+        // Remember this turn's file_read answers for the identical-re-read short-circuit. Only from
+        // turns with NO destructive call: a write in the same turn could have rewritten the file
+        // AFTER the read ran (reads precede the write barrier), and a fingerprint taken now would
+        // then attest to content the cached result does not show. Read-only turns — the dribble
+        // pattern this exists for — all record.
+        let turn_has_write = calls.iter().any(|tc| {
+            registry
+                .get(&tc.function.name)
+                .map(|t| t.is_destructive())
+                .unwrap_or(true)
+        });
+        if !turn_has_write {
+            for (k, (tc, (call_id, result))) in calls.iter().zip(results.iter()).enumerate() {
+                if tc.function.name != "file_read"
+                    || result.starts_with("error:")
+                    || result.starts_with("[unchanged]")
+                {
+                    continue;
+                }
+                let Ok(args) = parse_call_args(&tc.function.arguments) else {
+                    continue;
+                };
+                // The batch (`files:[…]`) form mixes several files in one result — one fingerprint
+                // cannot attest to it. Only the single-path form is cached.
+                if args.get("files").is_some() {
+                    continue;
+                }
+                let Some(path) = args.get("path").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let Ok(resolved) =
+                    crate::agent::builtin::confine(&cfg.effective_root(), path, true)
+                else {
+                    continue;
+                };
+                let Ok(bytes) = std::fs::read(&resolved) else {
+                    continue;
+                };
+                if read_cache.len() >= 512 {
+                    read_cache.clear(); // bounded; a dropped entry only costs a re-read
+                }
+                read_cache.insert(
+                    canonical_args(&tc.function.arguments),
+                    ReadCacheEntry {
+                        path: resolved,
+                        fingerprint: crate::core::persist::FileFingerprint::for_bytes(&bytes),
+                        msg_index: base + k,
+                        call_id: call_id.clone(),
+                        result_chars: result.chars().count(),
+                        result_prefix: result.chars().take(48).collect(),
+                    },
+                );
+            }
+        }
+
+        // BATCH-COACH: three consecutive turns that each made exactly ONE read-only retrieval call
+        // is the dribble pattern the system prompt already warns about — name it mid-run, where the
+        // habit is visible. A system nudge rides the NEXT request (zero extra round-trips), once
+        // per run.
+        let is_read_lane = |name: &str| {
+            matches!(
+                name,
+                "file_read"
+                    | "search_files"
+                    | "file_glob"
+                    | "codebase_search"
+                    | "read_symbol"
+                    | "memory_search"
+                    | "web_fetch"
+                    | "web_search"
+            ) || name.starts_with("lsp_")
+        };
+        if calls.len() == 1 && is_read_lane(&calls[0].function.name) {
+            single_read_streak += 1;
+        } else {
+            single_read_streak = 0;
+        }
+        if !batch_nudged && single_read_streak >= BATCH_COACH_AFTER {
+            batch_nudged = true;
+            push_nudge(
+                messages,
+                NUDGE_BATCH,
+                "[batch] Your last few turns each made a single read-only call. Batch independent \
+                 reads/searches into ONE turn as parallel tool calls — file_read takes \
+                 files:[{path,start,end},…], search_files takes context:N — and sequence only when \
+                 one result decides the next call.",
+            );
         }
 
         // EVIDENCE / STALL GUARD: a turn is informative when it adds facts, changes the workspace, or
@@ -3683,6 +3818,26 @@ fn summarize_result(name: &str, out: &str) -> (bool, String) {
 /// Pagination fields (e.g. file_read's start/end) are DELIBERATELY kept: a different read window is
 /// different work; a re-read returning identical bytes is caught by the content-novelty thrash guard
 /// instead (stripping them would flag legit sequential paging as divergence).
+/// One remembered `file_read` answer for the identical-re-read short-circuit: enough to prove
+/// "this exact call, against this exact file content, already answered — and its answer is still
+/// verbatim in history". All legs must hold; any miss falls back to a normal read. A false
+/// negative costs nothing, a false positive would starve the model of content it needs — so every
+/// check is byte-level.
+struct ReadCacheEntry {
+    /// Resolved on-disk path, for the fingerprint re-check.
+    path: std::path::PathBuf,
+    /// Fingerprint of the file bytes the cached result described. Recorded only from turns with
+    /// NO destructive call, so it provably equals the content at read time (nothing in the same
+    /// turn could have rewritten the file between the read and the record).
+    fingerprint: crate::core::persist::FileFingerprint,
+    /// Where the result message sat when recorded — revalidated against id+len+prefix below, so a
+    /// shifted (compacted) or blanked (evicted) history can never false-match.
+    msg_index: usize,
+    call_id: String,
+    result_chars: usize,
+    result_prefix: String,
+}
+
 fn turn_signature(calls: &[ToolCall]) -> String {
     let mut sigs: Vec<String> = calls
         .iter()
@@ -4494,6 +4649,13 @@ const TODO_POKE_PREFIX: &str = "[todo-poke]";
 const CONFIDENCE_GATE_PREFIX: &str = "[confidence-gate]";
 /// P0.3 hill-climb reframe / remeasure (system nudge via push_nudge).
 const NUDGE_HILL_CLIMB: &str = "[hill-climb]";
+/// Batch-coach (system nudge via push_nudge, once per run): fires after several consecutive
+/// turns that each made exactly ONE read-only call — measured sessions dribble 91% single-call
+/// turns despite the system prompt asking for batching, so the reminder lands mid-run where the
+/// habit is visible, at zero extra round-trips.
+const NUDGE_BATCH: &str = "[batch]";
+/// Consecutive one-read-call turns before the batch coach speaks. Three is a pattern, not luck.
+const BATCH_COACH_AFTER: usize = 3;
 /// GOAL MODE poke (user role — hard block path): the model tried to stop without having declared
 /// completion via `goal_complete`, so we re-inject the goal text and keep it working. Mirrors the
 /// todo-poke gate's shape (a `user` message the model can't ignore), not a soft system nudge.
@@ -9332,6 +9494,176 @@ mod tests {
             "poke lists the open item"
         );
         todo::clear();
+    }
+
+    #[tokio::test]
+    async fn done_gates_merge_into_one_round_trip() {
+        // self-review (nudge mode) + incomplete todos both fire on the SAME "done" claim: the old
+        // cascade spent one LLM round-trip PER gate; the merged flush carries both demands in ONE
+        // combined user message, with each gate's budget/latch consumed exactly as before.
+        let _t = todo::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _h = crate::core::config::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        todo::set(vec![todo::Todo::new("open-item", todo::Status::Pending)]);
+        let r = registry();
+        let c = AgentConfig {
+            enable_self_review: true,
+            enable_todo_poke: true,
+            max_todo_poke_attempts: 1,
+            approval_mode: crate::core::approval::ApprovalMode::Yolo,
+            max_iters: 8,
+            auto_extend_to: 8,
+            ..cfg()
+        };
+        let mut messages = vec![Message::system("sys"), Message::user("edit something")];
+        let chat = scripted(vec![
+            tool_turn("delete", "{}"), // successful destructive op arms made_any_edits
+            final_turn("first done"),  // BOTH gates fire here — one merged message
+            final_turn("second done"), // both budgets spent → accepted
+        ]);
+        let out = run_agent_loop(chat, &c, &r, &mut messages).await.unwrap();
+        assert_eq!(out.stop, StopReason::Done);
+        assert_eq!(out.final_text.as_deref(), Some("second done"));
+        let merged: Vec<&Message> = messages
+            .iter()
+            .filter(|m| {
+                m.role == "user"
+                    && m.content
+                        .as_deref()
+                        .is_some_and(|c| c.starts_with("Multiple checks fired"))
+            })
+            .collect();
+        assert_eq!(merged.len(), 1, "one combined message, not one per gate");
+        let body = merged[0].content.as_deref().unwrap();
+        assert!(body.contains("[self-review]"), "{body}");
+        assert!(body.contains(TODO_POKE_PREFIX), "{body}");
+        // The old one-gate-one-message shape is gone: neither demand went out standalone.
+        assert!(
+            !messages.iter().any(|m| {
+                m.role == "user"
+                    && m.content.as_deref().is_some_and(|c| {
+                        c.starts_with("[self-review]") || c.starts_with(TODO_POKE_PREFIX)
+                    })
+            }),
+            "both demands rode the merged message"
+        );
+        assert_valid_history(&messages);
+        todo::clear();
+    }
+
+    /// A stub named `file_read` — the loop's re-read short-circuit and batch coach key on the tool
+    /// NAME, and the property under test is the LOOP's bookkeeping, not the real reader's slicing.
+    struct StubFileRead;
+    impl Tool for StubFileRead {
+        fn name(&self) -> &str {
+            "file_read"
+        }
+        fn description(&self) -> &str {
+            "stub file reader"
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type":"object","properties":{"path":{"type":"string"}},"required":["path"]})
+        }
+        fn execute(&self, args: &serde_json::Value) -> Result<String> {
+            let p = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+            Ok(std::fs::read_to_string(p)?)
+        }
+    }
+
+    #[tokio::test]
+    async fn identical_re_read_short_circuits_only_while_unchanged() {
+        let dir = std::env::temp_dir().join(format!("aizen-reread-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("a.txt");
+        std::fs::write(&file, "alpha").unwrap();
+        let args = serde_json::json!({"path": file.to_string_lossy()}).to_string();
+        let mut r = ToolRegistry::new();
+        r.register(Box::new(StubFileRead));
+        let c = AgentConfig {
+            max_iters: 10,
+            auto_extend_to: 10,
+            ..cfg()
+        };
+        let mut messages = vec![Message::system("sys"), Message::user("read it")];
+        // Turn 1 reads. Turn 2 repeats the call byte-for-byte → short-circuited. Before turn 3 the
+        // CHAT CLOSURE rewrites the file, so the third identical call must fall through to a real
+        // read (the fingerprint leg fails) — a false "unchanged" here would starve the model.
+        let file_for_chat = file.clone();
+        let turns = Mutex::new(VecDeque::from(vec![
+            tool_turn("file_read", &args),
+            tool_turn("file_read", &args),
+            tool_turn("file_read", &args),
+            final_turn("done"),
+        ]));
+        let chat = move |_m: Vec<Message>, _d: Vec<ToolDef>| {
+            let mut q = turns.lock().unwrap();
+            if q.len() == 2 {
+                // about to hand out the THIRD call — change the file under it
+                std::fs::write(&file_for_chat, "beta").unwrap();
+            }
+            std::future::ready(Ok(q.pop_front().unwrap_or_else(|| final_turn("stop"))))
+        };
+        let out = run_agent_loop(chat, &c, &r, &mut messages).await.unwrap();
+        assert_eq!(out.stop, StopReason::Done);
+        let tool_bodies: Vec<&str> = messages
+            .iter()
+            .filter(|m| m.role == "tool")
+            .filter_map(|m| m.content.as_deref())
+            .collect();
+        assert_eq!(tool_bodies.len(), 3, "{tool_bodies:?}");
+        assert_eq!(tool_bodies[0], "alpha");
+        assert!(
+            tool_bodies[1].starts_with("[unchanged]"),
+            "byte-identical repeat of an unchanged file answers with a pointer: {}",
+            tool_bodies[1]
+        );
+        assert_eq!(
+            tool_bodies[2], "beta",
+            "a changed file must be re-read for real, never short-circuited"
+        );
+        assert_valid_history(&messages);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn batch_coach_nudges_once_after_a_single_read_streak() {
+        let dir = std::env::temp_dir().join(format!("aizen-batchcoach-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut turns = Vec::new();
+        for i in 0..4 {
+            let f = dir.join(format!("f{i}.txt"));
+            std::fs::write(&f, format!("body-{i}")).unwrap();
+            let args = serde_json::json!({"path": f.to_string_lossy()}).to_string();
+            turns.push(tool_turn("file_read", &args));
+        }
+        turns.push(final_turn("done"));
+        let mut r = ToolRegistry::new();
+        r.register(Box::new(StubFileRead));
+        let c = AgentConfig {
+            max_iters: 10,
+            auto_extend_to: 10,
+            ..cfg()
+        };
+        let mut messages = vec![Message::system("sys"), Message::user("survey the files")];
+        let out = run_agent_loop(scripted(turns), &c, &r, &mut messages)
+            .await
+            .unwrap();
+        assert_eq!(out.stop, StopReason::Done);
+        let coach_count = messages
+            .iter()
+            .filter(|m| {
+                m.content
+                    .as_deref()
+                    .is_some_and(|c| c.starts_with(NUDGE_BATCH))
+            })
+            .count();
+        // Fired at streak 3, latched thereafter — the 4th single read must not re-nudge.
+        assert_eq!(coach_count, 1, "one batch-coach nudge per run");
+        assert_valid_history(&messages);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Steering is a process-global mailbox (the keyboard thread has no handle on the running turn),

--- a/src/agent/search.rs
+++ b/src/agent/search.rs
@@ -28,6 +28,9 @@ const MAX_LINE_CHARS: usize = 240;
 /// Hard wall-clock cap so a search over a giant tree can't freeze the agent loop (the parallel walk
 /// checks this per file and quits every thread once it trips).
 const SEARCH_TIMEOUT: Duration = Duration::from_secs(10);
+/// Cap on `context` — ±10 lines already shows a whole function around most matches; more is a
+/// file read wearing a search costume.
+const MAX_CONTEXT: usize = 10;
 
 /// Decode a file's bytes to searchable text, detecting UTF-16 (P2.2). A UTF-16-encoded source file
 /// (common on Windows — PowerShell `>` redirection, some editors, .NET logs) is `byte,0,byte,0…`,
@@ -94,11 +97,11 @@ impl Tool for SearchFiles {
         "search_files"
     }
     fn description(&self) -> &str {
-        "Search file CONTENT by regular expression. Defaults to the working directory but `path` may \
-         be a ../ or absolute directory elsewhere. By default respects .gitignore and skips hidden + \
-         binary files; set hidden:true to also search hidden files and ignored/build dirs. Returns \
-         `path:line: matched text`. This is the canonical content search — do NOT shell out to \
-         grep/ripgrep, and do NOT use file_glob (that matches file NAMES, not content). Read-only."
+        "Search file CONTENT by regular expression (`path` may be a ../ or absolute dir elsewhere). \
+         Respects .gitignore and skips hidden + binary files unless hidden:true. Returns \
+         `path:line: matched text`; context:N adds ±N surrounding lines (grep -C) so a follow-up \
+         file_read is rarely needed. The canonical content search — do NOT shell out to \
+         grep/ripgrep; file_glob matches NAMES, not content. Read-only."
     }
     fn parameters(&self) -> Value {
         serde_json::json!({
@@ -110,7 +113,8 @@ impl Tool for SearchFiles {
                 "glob": {"type": "string", "description": "optional file glob to restrict which files are searched, e.g. *.rs or src/**/*.ts"},
                 "ignore_case": {"type": "boolean", "description": "case-insensitive match (default false)"},
                 "hidden": {"type": "boolean", "description": "also search hidden files and .gitignored paths (default false)"},
-                "max_results": {"type": "integer", "description": "cap on matches returned (default 200)"}
+                "max_results": {"type": "integer", "description": "cap on matches returned (default 200)"},
+                "context": {"type": "integer", "description": "lines of context around each match, grep -C style (default 0, max 10)"}
             },
             "required": ["pattern"]
         })
@@ -128,6 +132,11 @@ impl Tool for SearchFiles {
             .get("max_results")
             .and_then(|v| v.as_u64())
             .unwrap_or(DEFAULT_MAX_RESULTS as u64) as usize;
+        let ctx = args
+            .get("context")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+            .min(MAX_CONTEXT as u64) as usize;
         let re = RegexBuilder::new(pattern)
             .case_insensitive(ignore_case)
             .build()
@@ -165,7 +174,12 @@ impl Tool for SearchFiles {
         // over a huge tree can't freeze the agent loop. Results, the match counter, and the
         // skipped-large-file counter are shared behind a `Mutex`/atomics. Per-file work (read →
         // binary/UTF-16 classify → line-scan) happens on the worker thread.
-        let results: Mutex<Vec<(PathBuf, usize, String)>> = Mutex::new(Vec::new());
+        // Per file: (path, rows), each row = (1-based line, clipped text, is_match). With
+        // context=0 the rows are exactly the match lines (the classic flat shape); with context>0
+        // they are the MERGED ±ctx windows around the matches, so an overlapping pair of matches
+        // never prints a line twice.
+        type FileRows = (PathBuf, Vec<(usize, String, bool)>);
+        let results: Mutex<Vec<FileRows>> = Mutex::new(Vec::new());
         let files_hit = AtomicUsize::new(0);
         let match_count = AtomicUsize::new(0);
         let skipped_large = AtomicUsize::new(0);
@@ -208,35 +222,68 @@ impl Tool for SearchFiles {
                     .strip_prefix(&self.root)
                     .unwrap_or(dent.path())
                     .to_path_buf();
-                let mut this_file = false;
+                // Pass 1: collect this file's match line numbers (1-based) under the global cap.
+                let mut hit_lines: Vec<usize> = Vec::new();
                 for (i, line) in text.lines().enumerate() {
                     if re.is_match(line) {
-                        this_file = true;
-                        let trimmed = line.trim_end();
-                        let shown: String = if trimmed.chars().count() > MAX_LINE_CHARS {
-                            trimmed.chars().take(MAX_LINE_CHARS).collect::<String>() + "…"
-                        } else {
-                            trimmed.to_string()
-                        };
                         let n = match_count.fetch_add(1, Ordering::Relaxed);
                         if n >= max_results {
                             truncated.store(true, Ordering::Relaxed);
                             break;
                         }
-                        results.lock().unwrap().push((rel.clone(), i + 1, shown));
+                        hit_lines.push(i + 1);
                     }
                 }
-                if this_file {
-                    files_hit.fetch_add(1, Ordering::Relaxed);
+                if hit_lines.is_empty() {
+                    return WalkState::Continue;
                 }
+                files_hit.fetch_add(1, Ordering::Relaxed);
+                // Pass 2: materialize rows — the match lines alone, or their merged ±ctx windows.
+                let lines: Vec<&str> = text.lines().collect();
+                let clip = |line: &str| -> String {
+                    let trimmed = line.trim_end();
+                    if trimmed.chars().count() > MAX_LINE_CHARS {
+                        trimmed.chars().take(MAX_LINE_CHARS).collect::<String>() + "…"
+                    } else {
+                        trimmed.to_string()
+                    }
+                };
+                let rows: Vec<(usize, String, bool)> = if ctx == 0 {
+                    hit_lines
+                        .iter()
+                        .map(|&n| (n, clip(lines[n - 1]), true))
+                        .collect()
+                } else {
+                    let mut windows: Vec<(usize, usize)> = Vec::new();
+                    for &n in &hit_lines {
+                        let s = n.saturating_sub(ctx).max(1);
+                        let e = (n + ctx).min(lines.len());
+                        match windows.last_mut() {
+                            // Merge overlapping/adjacent windows so no line prints twice.
+                            Some((_, prev_end)) if s <= *prev_end + 1 => {
+                                *prev_end = (*prev_end).max(e)
+                            }
+                            _ => windows.push((s, e)),
+                        }
+                    }
+                    let hits: std::collections::HashSet<usize> =
+                        hit_lines.iter().copied().collect();
+                    windows
+                        .iter()
+                        .flat_map(|&(s, e)| {
+                            (s..=e).map(|n| (n, clip(lines[n - 1]), hits.contains(&n)))
+                        })
+                        .collect()
+                };
+                results.lock().unwrap().push((rel, rows));
                 WalkState::Continue
             })
         });
 
         let mut results = results.into_inner().unwrap();
         // The parallel walk collects in nondeterministic order; sort so output is stable/readable.
-        results.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-        results.truncate(max_results);
+        // (Rows within a file are already in line order — built by one worker in one pass.)
+        results.sort_by(|a, b| a.0.cmp(&b.0));
         let files_hit = files_hit.load(Ordering::Relaxed);
         let skipped_large = skipped_large.load(Ordering::Relaxed);
 
@@ -253,11 +300,28 @@ impl Tool for SearchFiles {
             }
             return Ok(msg);
         }
-        let lines: Vec<String> = results
+        let shown_matches: usize = results
             .iter()
-            .map(|(rel, n, shown)| format!("{}:{}: {}", rel.display(), n, shown))
-            .collect();
-        let mut out = format!("{} match(es) in {files_hit} file(s):", lines.len());
+            .map(|(_, rows)| rows.iter().filter(|r| r.2).count())
+            .sum();
+        // grep's own convention: `path:line:` marks a MATCH row, `path-line-` a context row, `--`
+        // separates non-contiguous groups — a shape every model already knows how to read.
+        let mut lines: Vec<String> = Vec::new();
+        for (rel, rows) in &results {
+            let mut prev: Option<usize> = None;
+            for (n, shown, is_match) in rows {
+                if !lines.is_empty() && ctx > 0 && prev.is_none_or(|p| *n != p + 1) {
+                    lines.push("--".to_string());
+                }
+                if *is_match {
+                    lines.push(format!("{}:{}: {}", rel.display(), n, shown));
+                } else {
+                    lines.push(format!("{}-{}- {}", rel.display(), n, shown));
+                }
+                prev = Some(*n);
+            }
+        }
+        let mut out = format!("{shown_matches} match(es) in {files_hit} file(s):");
         out.push('\n');
         out.push_str(&lines.join("\n"));
         if truncated.load(Ordering::Relaxed) {
@@ -383,6 +447,51 @@ mod tests {
             .execute(&serde_json::json!({"pattern": "secret"}))
             .unwrap();
         assert!(out.contains("cfg.ts"), "utf-16 file searched: {out}");
+    }
+
+    #[test]
+    fn context_lines_wrap_matches_and_merge_overlapping_windows() {
+        let root = tmp("context");
+        // Lines 1..=12; matches at 4 and 6 (windows ±2 overlap → ONE merged group 2..=8) and at 12.
+        let body = (1..=12)
+            .map(|i| {
+                if i == 4 || i == 6 || i == 12 {
+                    format!("needle line {i}")
+                } else {
+                    format!("plain line {i}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(root.join("ctx.txt"), body).unwrap();
+        let t = SearchFiles::new(root);
+        let out = t
+            .execute(&serde_json::json!({"pattern": "needle", "context": 2}))
+            .unwrap();
+        assert!(
+            out.starts_with("3 match(es) in 1 file(s):"),
+            "header counts MATCHES, not rows: {out}"
+        );
+        // Match rows use `path:line:`, context rows `path-line-` (grep -C convention).
+        assert!(out.contains("ctx.txt:4: needle line 4"), "{out}");
+        assert!(out.contains("ctx.txt-3- plain line 3"), "{out}");
+        // Overlapping windows merged: line 5 (between the 4 and 6 matches) appears exactly once.
+        assert_eq!(out.matches("plain line 5").count(), 1, "{out}");
+        // Non-contiguous groups separated by `--`: the 2..=8 block vs the 10..=12 block.
+        assert!(out.contains("--"), "{out}");
+        assert!(
+            !out.contains("plain line 9"),
+            "gap line outside both windows: {out}"
+        );
+        // context:0 (default) keeps the classic flat shape.
+        let flat = t2_flat(&t);
+        assert!(flat.contains("ctx.txt:4: needle line 4"), "{flat}");
+        assert!(!flat.contains("-3-"), "no context rows by default: {flat}");
+    }
+
+    fn t2_flat(t: &SearchFiles) -> String {
+        t.execute(&serde_json::json!({"pattern": "needle"}))
+            .unwrap()
     }
 
     #[test]

--- a/src/agent/system_prompt.md
+++ b/src/agent/system_prompt.md
@@ -46,7 +46,8 @@ Do the whole loop this turn. Don't hand back at the first obstacle — diagnose 
 - Take the next concrete step instead of describing it. Batch independent steps into ONE turn
   (parallel calls): reads and searches of any kind. A turn may mix one edit or command with reads —
   writes run in order, the round-trips still merge. Only sequence when one call's output feeds the
-  next.
+  next. Even a single call can batch: `file_read files:[{path,start,end},…]` reads several slices
+  at once, and `search_files context:N` returns surrounding lines so no follow-up read is needed.
 - Example — "fix the failing parse test": a good FIRST turn is three calls at once — search for the
   function, read the test file, read the source file — not three separate turns.
 

--- a/src/agent/system_prompt_strict.md
+++ b/src/agent/system_prompt_strict.md
@@ -15,8 +15,9 @@ is attached to the request. Call nothing that is not in that list.
    read the file. Don't guess paths, contents, or APIs. Use the file-finding tool, NEVER a shell
    `where` / `dir /s` / `Get-ChildItem -Recurse` / `find` / `fd` (slow on big trees, not always
    installed).
-4. Batch independent reads/searches into ONE turn (parallel calls). Only sequence when one call's
-   output feeds the next.
+4. Batch independent reads/searches into ONE turn (parallel calls); `file_read files:[…]` reads
+   several slices in one call, `search_files context:N` includes surrounding lines. Only sequence
+   when one call's output feeds the next.
 5. Read before you edit. Prefer rewriting a whole named item by symbol over hunting exact strings;
    for a small region copy the surrounding text EXACTLY; batch several edits to one file into ONE
    call. NEVER create, blank, or overwrite a file through the shell (redirection, `Set-Content`,


### PR DESCRIPTION
> **Stacked on #19** — merge that first. Until it lands this PR shows its two commits as well; only
> `perf(agent): cut LLM round-trips…` is new here.

## What does this PR do?

Reduces how many model round-trips a task costs, without loosening any correctness gate.

### The measurement first

Across the 16 most recent real sessions on this machine (633 tool calls):

| observation | number |
|---|---|
| assistant turns that made exactly **one** tool call | **91.4%** (481/526) |
| tool calls that re-hit a target the same tool had already hit | **30%** (190/633) |
| injected gate/nudge messages | 2.7% of all messages |

The system prompt has asked for batched parallel calls since July and the model still dribbles one
call per turn, so this changes what the tools and the loop make *possible* rather than adding more
words to the prompt.

### Changes

- **`file_read` takes `files:[{path,start,end},…]`** — up to 8 files or slices in one call. Per-entry
  errors are reported inline so one missing file does not void the batch, and whole-file entries
  share the single-call budget so a batch cannot return N times what one call may.
- **`search_files` takes `context:N`** (grep -C). Overlapping windows are merged so no line prints
  twice; match rows keep `path:line:` and context rows use `path-line-`. A search result no longer
  forces a follow-up read. `context:0` is byte-identical to today's output.
- **The done-gate cascade merges.** Verify failure, self-review, todo-poke and the confidence gate
  now append to one demand list and ride a **single** round-trip instead of one LLM call per gate —
  up to four sequential round-trips collapse into one. Per-gate budgets and latches are consumed
  exactly as before, and with one demand the message is byte-identical to what the old cascade sent.
  The goal and steering gates stay exclusive: the goal gate's pending claim may only be drained at a
  real Done decision.
- **An identical re-read short-circuits.** A `file_read` whose canonical args match an earlier call,
  whose file bytes are unchanged, and whose earlier result is still verbatim in history answers with
  a one-line pointer instead of the same content again. All three legs are byte-level; the cache
  only records from turns with **no** destructive call, because a write in the same turn could have
  changed the file after the read ran.
- **A batch coach** fires once per run after three consecutive single-read turns — a system nudge
  that rides the next request and costs no extra round-trip.

### What this deliberately does not touch

Shell/build/test turns are 41% of all calls and are a genuinely sequential edit-test cycle. The
re-read short-circuit only catches byte-identical repeats — a false "unchanged" would starve the
model of content it needs, so a near-miss re-read still runs for real.

The "after" number is not measured yet: this needs to run in a released binary and accumulate new
sessions before the same analysis can be repeated honestly.

## Base branch

- [x] This PR targets **dev**.

## Type of change

- [x] New feature (batched reads, search context)
- [x] Refactor (the merged gate cascade — same demands, fewer round-trips)

## Checklist

- [x] `cargo test --bin aizen` green — 1713 tests on this branch, with 6 new ones covering the batch
      read, the merged context windows, the merged cascade, unchanged-vs-changed re-reads and the
      coach latch.
- [x] `cargo fmt` clean, `cargo clippy` clear for the lines introduced.
- [x] Pure-Rust single-static-binary posture unchanged; no new dependency.

## Notes for the reviewer

The tool-schema ratchet caught `search_files` at 1467 B against the 1400 B per-tool ceiling, so its
description was compressed rather than the ceiling raised.

Two full-suite runs on this branch failed on unrelated tests before #20; that flake is fixed there
and is not caused by this change.