### PR TITLE
release: 0.6.6 — the prompt you typed stays where you can read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ development log lives in that monorepo's history.
 
 ## [Unreleased]
 
+## [0.6.6] — 2026-08-21
+
 ### Added
+- **The composer wraps a long prompt down instead of hiding it.** The input box was ONE physical
+  row: a prompt wider than it scrolled sideways, so everything left of the window was off screen —
+  unreadable, and (the hit-test being single-row) unselectable, which left Ctrl-C taking ALL of it
+  as the only way to get your own text back. It now grows downward. Width breaks prefer the last
+  space on the row so a wrapped prompt reads as prose, a word wider than the box still breaks hard,
+  and an embedded newline keeps a blank cell of its own so a click at the end of a line parks the
+  caret BEFORE the break rather than at the start of the next. The box stops at 10 rows and never
+  leaves the transcript under 3; past that it scrolls by row — stickily, so a caret already on
+  screen never drags the window — and the framing rules carry the hidden-row count (`↑12` / `↓3`),
+  because a capped box that said nothing would read as a truncated one. The click map is multi-row,
+  so a drag now selects across wrapped rows and the copy comes back with its newlines intact. ↑/↓
+  walk the rows of a multi-line draft before they mean history recall: the first ↑ inside a pasted
+  block used to swap the whole block out for the last message.
+- **`aizen agent --image <PATH>`.** Vision was REPL-only — drag a file onto the window, or Ctrl-O
+  for a screenshot — so a front-end driving the headless entry point could describe a picture but
+  never show one. The flag inlines a PNG/JPEG/GIF/WebP (≤ 8 MB) into the first user message as an
+  `image_url` data part, the same wire shape the REPL's attach paths produce; repeat it for more
+  than one. The files are read **before** the endpoint is resolved, so a mistyped path costs a
+  failed open rather than a billed request, and a path that is not a readable image ends the run
+  instead of being skipped: this is the scripting and CI entry point, and an attachment that
+  silently vanished would yield a confident answer about an image nothing ever sent. Note the
+  deliberate difference from the REPL, where a typed line lifts only real image paths and leaves
+  anything else as prose — right for something a human typed, wrong for a flag. Omit it and the
+  request is byte-identical to one from a core that never had it.
 - **`aizen config set` reaches the twelve keys it could not.** `update_check`, `skill_registry`,
   `max_tokens`, `prompt_cache`, `prompt_tier`, `eager_tools`, `self_review`,
   `max_parallel_subagents`, `workflow_tool`, `embed_model`, `timemachine_keep_safety` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aizen"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aizen"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 description = "Aizen first-party agentic coding CLI — OpenAI-compatible, hermes-style provider-agnostic API client"
 license = "Apache-2.0"

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -352,6 +352,7 @@ aizen agent --yes "fix the failing test in src/parse.rs"   # pre-approve file/sh
 aizen agent --max-iters 40 "..."                            # raise the step cap
 aizen agent --save-session "..."                            # keep the transcript for /sessions
 aizen agent --effort high "..."                             # this run only; the config is untouched
+aizen agent --image shot.png "why is this button misaligned?"  # vision: repeat --image for more
 ```
 Behavior worth knowing:
 - **Nothing is saved unless you ask.** This subcommand is also the scripting and CI entry point, so
@@ -367,6 +368,15 @@ Behavior worth knowing:
   typed REPL turn goes through, against the task text. Omit the flag and nothing changes: the
   configured `reasoning_effort` applies and the request is byte-identical to one from a core that
   never had the flag. The tier is named on **stderr**, next to the rest of the trace.
+- **Images are attached, not described.** `--image <PATH>` inlines a PNG/JPEG/GIF/WebP (≤ 8 MB) into
+  the first user message as an `image_url` data part — the same wire shape the REPL produces when you
+  drag a file onto the window or press Ctrl-O to grab a screenshot — so a front-end driving this
+  subcommand gets vision without driving the REPL. Repeat the flag for more than one image. The model
+  must be vision-capable; the files are read **before** the endpoint is resolved, and a path that is
+  not a readable image ends the run there rather than being skipped, because an attachment that
+  silently vanished would yield a confident answer about an image nothing ever sent. Note the
+  difference from the REPL: a typed line only lifts paths that really are images and leaves anything
+  else as prose, which is right for something a human typed — a flag is deliberate, so it is loud.
 - **How tools reach the model** — the session's tool registry is the single source of truth. Its
   definitions (name, description, JSON Schema) are sent through the provider's **native** tool field:
   OpenAI-compatible gateways and Anthropic get `tools[{type:"function",function:{…}}]`, the ChatGPT

--- a/src/cli/run_cmds.rs
+++ b/src/cli/run_cmds.rs
@@ -328,6 +328,15 @@ pub(crate) async fn run_agent_cmd(args: AgentArgs) -> Result<()> {
     if args.task.trim().is_empty() {
         anyhow::bail!("empty task (pass the task as the first argument)");
     }
+    // Read before the endpoint is resolved, so a mistyped path costs a failed open rather than a
+    // billed request. Loud rather than skipped: this is the scripting and CI entry point, and an
+    // attachment that quietly vanished would produce a confident answer about an image the model
+    // never saw — the one failure mode a vision flag must not have.
+    let images = args
+        .image
+        .iter()
+        .map(|p| crate::ui::image_input::image_file_to_data_url(p))
+        .collect::<Result<Vec<_>>>()?;
     let (base_url, api_key, model) = resolve_endpoint(args.base_url, args.api_key, args.model)?;
     let http = http_client()?;
 
@@ -419,7 +428,18 @@ pub(crate) async fn run_agent_cmd(args: AgentArgs) -> Result<()> {
     // The transcript is built here rather than inside `run_agent` so this path can still hold it
     // afterwards: the loop appends every turn — the final answer included — to the vector it is
     // handed, and `run_agent` is exactly these two opening messages plus that call.
-    let mut history = vec![Message::system(&system), Message::user(args.task.trim())];
+    // One user turn either way. With attachments it serializes as a parts array (text first, then
+    // one image_url part each) instead of a plain string, which is the only difference on the wire.
+    let asked = if images.is_empty() {
+        Message::user(args.task.trim())
+    } else {
+        eprintln!(
+            "{}",
+            style(format!("📎 {} image(s) attached", images.len())).dim()
+        );
+        Message::user_with_images(args.task.trim(), images)
+    };
+    let mut history = vec![Message::system(&system), asked];
     let result = agent::run_agent_loop(chat, &cfg, &registry, &mut history).await;
     // Saved before the error is propagated. A run that ended badly still happened, and the REPL
     // treats persistence as not optional — that promise should not be weaker off a terminal.

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -1043,6 +1043,12 @@ pub(crate) struct AgentArgs {
     /// `reasoning_effort` is used, exactly as before. This flag never writes the config.
     #[arg(long, value_parser = ["auto", "low", "medium", "high", "xhigh", "max"])]
     pub(crate) effort: Option<String>,
+    /// Attach an image for the model to SEE — PNG/JPEG/GIF/WebP, up to 8 MB each. Repeat the flag
+    /// for more than one. Needs a vision-capable model: the file is inlined into the first user
+    /// message as an `image_url` data part, the same shape the REPL's drag-drop and Ctrl-O
+    /// attach produce. A path that is not a readable image fails the run rather than being dropped.
+    #[arg(long = "image", value_name = "PATH")]
+    pub(crate) image: Vec<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/tests/main_suite.rs
+++ b/src/tests/main_suite.rs
@@ -129,6 +129,40 @@ fn agent_effort_takes_the_ladder_and_nothing_else() {
     assert!(Cli::try_parse_from(["aizen", "agent", "--effort", "mediumish", "việc"]).is_err());
 }
 
+/// `--image` takes a value, repeats, and must never be mistaken for the task.
+///
+/// The task is positional, so every flag on this subcommand is one bad definition away from
+/// swallowing it. A front-end sends `--image <path> <task>`, and if the flag were ever made
+/// optional-valued clap would read the task as the path: the run would then fail with "not a
+/// PNG/JPEG/GIF/WebP image" naming the user's own sentence, which is a mystifying way to say
+/// nothing was attached. Repeatable because one screenshot is the common case and two is not rare.
+#[test]
+fn agent_image_is_repeatable_and_never_eats_the_task() {
+    let cli = Cli::try_parse_from([
+        "aizen",
+        "agent",
+        "--image",
+        "a.png",
+        "--image",
+        "b.jpg",
+        "cái nút này sai chỗ nào",
+    ])
+    .expect("parse");
+    let Some(Commands::Agent(args)) = cli.command else {
+        panic!("expected the agent subcommand");
+    };
+    assert_eq!(args.image, vec!["a.png".to_string(), "b.jpg".to_string()]);
+    assert_eq!(args.task, "cái nút này sai chỗ nào");
+
+    // Omitted is the old shape exactly: no parts array, no image field, a request byte-identical
+    // to one from a core that never had this flag.
+    let plain = Cli::try_parse_from(["aizen", "agent", "chạy test"]).expect("parse");
+    assert!(matches!(plain.command, Some(Commands::Agent(a)) if a.image.is_empty()));
+
+    // A value is required, so the flag can never stand alone and leave the task unaccounted for.
+    assert!(Cli::try_parse_from(["aizen", "agent", "--image"]).is_err());
+}
+
 /// `memory list current` and `memory list --scope current` must mean the same thing.
 ///
 /// The REPL has always taken the scope positionally (`/memory list current`), so that is the form

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -756,6 +756,51 @@ fn draft_selection() -> Option<(usize, usize)> {
     normalized_draft_sel(r.draft_sel, r.draft.len())
 }
 
+/// Move the draft caret one LOGICAL line up (`dir < 0`) or down, keeping its column. `false` when the
+/// draft has no line that way — the caller then falls through to history recall, which is what ↑/↓
+/// still mean on a one-line draft.
+///
+/// The composer paints a multi-line draft over several rows now, so ↑/↓ walking those rows is what
+/// the box looks like it should do. Without this the first ↑ inside a pasted block swaps the whole
+/// block out for the last message, which reads as losing it.
+fn move_draft_caret_line(dir: i32) -> bool {
+    let mut r = render().lock().unwrap();
+    if !r.draft.contains(&'\n') {
+        return false;
+    }
+    let cursor = r.cursor.min(r.draft.len());
+    let line_start = r.draft[..cursor]
+        .iter()
+        .rposition(|&c| c == '\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let col = cursor - line_start;
+    if dir < 0 {
+        if line_start == 0 {
+            return false; // already on the first line
+        }
+        let prev_start = r.draft[..line_start - 1]
+            .iter()
+            .rposition(|&c| c == '\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        // The column is clamped to the shorter line, as every editor does.
+        let prev_len = line_start - 1 - prev_start;
+        r.cursor = prev_start + col.min(prev_len);
+    } else {
+        let Some(rel) = r.draft[cursor..].iter().position(|&c| c == '\n') else {
+            return false; // already on the last line
+        };
+        let next_start = cursor + rel + 1;
+        let next_len = r.draft[next_start..]
+            .iter()
+            .position(|&c| c == '\n')
+            .unwrap_or(r.draft.len() - next_start);
+        r.cursor = next_start + col.min(next_len);
+    }
+    true
+}
+
 /// Drop the highlight without touching the text, repainting only if there was one to drop.
 fn clear_draft_selection() {
     let had = {
@@ -2127,9 +2172,9 @@ fn handle_retained_mouse(
 /// Mouse inside the input box: click to park the caret, drag to select, release to copy. Returns
 /// whether the event belonged to the box (the caller then leaves the transcript alone).
 ///
-/// This is the mouse half of editing the draft. Without it the caret could only be walked with ←/→,
-/// which on a draft longer than the box also dragged the whole line under a stationary cursor, and the
-/// only way to copy what you had typed was Ctrl-C taking ALL of it.
+/// This is the mouse half of editing the draft. Without it the caret could only be walked with ←/→
+/// through a draft that may now be wrapped over several rows, and the only way to copy what you had
+/// typed was Ctrl-C taking ALL of it.
 ///
 /// The box's highlight and the transcript's are deliberately exclusive — Ctrl-C has one meaning at a
 /// time, so starting one drops the other rather than leaving two highlights on screen competing to be
@@ -2163,10 +2208,10 @@ fn handle_input_box_mouse(
             let Some(anchor) = *dragging_draft else {
                 return false;
             };
-            // Column only, row ignored: the pointer leaves a one-row box constantly while selecting
-            // inside it, and a drag that stopped extending the moment it strayed a row would be
-            // unusable. Off either end of the text it clamps to the nearest edge.
-            if let Some(idx) = retained::input_hit_col(col) {
+            // The row is CLAMPED into the box rather than required to be on it: the pointer leaves
+            // the box constantly while selecting inside it, and a drag that stopped extending the
+            // moment it strayed would be unusable. Off either end it clamps to the nearest edge.
+            if let Some(idx) = retained::input_hit_drag(col, row) {
                 set_draft_caret(idx, Some((anchor, idx)));
             }
             true
@@ -3274,6 +3319,12 @@ fn input_loop(
                     repaint();
                     continue;
                 }
+                // A multi-line draft is painted over several rows, so ↑ walks those rows first and
+                // only means history once the caret is on the top one.
+                if move_draft_caret_line(-1) {
+                    repaint();
+                    continue;
+                }
                 // ↑ at the prompt recalls the previous message (readline-style), in BOTH backends.
                 // Transcript scrolling lives on PageUp/PageDown, so arrows are never stolen from recall.
                 if history.is_empty() {
@@ -3311,6 +3362,11 @@ fn input_loop(
                         r.palette_sel = r.palette_sel.saturating_sub(1);
                     }
                     drop(r);
+                    repaint();
+                    continue;
+                }
+                // Symmetric to ArrowUp: inside a multi-line draft ↓ walks down its rows first.
+                if move_draft_caret_line(1) {
                     repaint();
                     continue;
                 }

--- a/src/ui/tui/retained.rs
+++ b/src/ui/tui/retained.rs
@@ -53,7 +53,15 @@ pub(super) use self::widgets::*;
 #[cfg(test)]
 mod tests;
 
+/// Smallest footer that can be painted at all: HUD + rule + one text row + rule. Below this the
+/// composer is skipped entirely rather than drawn half-formed.
 const FOOTER_ROWS: u16 = 4;
+/// The footer's fixed furniture — the HUD strip and the two framing rules. Everything on top of
+/// this is composer text, which is why the footer's height is decided per frame rather than fixed.
+const FOOTER_CHROME_ROWS: u16 = 3;
+/// Ceiling on how tall the composer may grow. A long prompt wraps DOWN instead of scrolling
+/// sideways out of sight, but past this many rows a pasted wall of text would become the screen.
+const MAX_INPUT_TEXT_ROWS: u16 = 10;
 const CACHE_LIMIT: usize = 512;
 const BLOCK_LIMIT: usize = 2048;
 
@@ -317,14 +325,14 @@ struct AppState {
     /// How many chars of `work_caption` are revealed so far — advanced one per animation tick for the
     /// typewriter effect, clamped to the caption length.
     work_reveal: usize,
-    /// Draft index of the first char visible in the input box at the last draw.
+    /// First WRAPPED ROW of the draft visible in the composer at the last draw.
     ///
-    /// The window is STICKY: it only slides when the caret would otherwise fall off an edge. Re-deriving
-    /// it from the caret every frame (what this used to do) pinned the caret to the right edge, so on a
-    /// draft longer than the box every ←/→ scrolled the whole line under a stationary cursor instead of
-    /// moving the cursor through stationary text — and a click could never land where it was aimed,
-    /// because the text jumped as soon as the caret moved.
-    input_win_start: usize,
+    /// The box grows downward with the draft, so this is only non-zero once the draft is taller than
+    /// the box will go (`MAX_INPUT_TEXT_ROWS`, or what the terminal leaves after the transcript's
+    /// floor). The window is STICKY: it slides only when the caret would otherwise fall off an edge.
+    /// Re-deriving it from the caret every frame would pin the caret to the bottom row, so scrolling
+    /// back up through a long paste would snap away on the next repaint.
+    input_row_scroll: usize,
 }
 
 /// Absolute character selection over the flat list of wrapped transcript rows.
@@ -371,7 +379,7 @@ impl AppState {
             work_verb: String::new(),
             work_caption: String::new(),
             work_reveal: 0,
-            input_win_start: 0,
+            input_row_scroll: 0,
         }
     }
 

--- a/src/ui/tui/retained/geom.rs
+++ b/src/ui/tui/retained/geom.rs
@@ -93,22 +93,33 @@ pub(super) fn menu_hit_index(g: &OverlayMenuGeom, col: u16, row: u16) -> Option<
     (idx < g.rows).then_some(idx)
 }
 
-/// Where the input box's typed text landed on screen at the last draw, so the input thread can turn a
-/// mouse column into a caret position in the draft.
+/// Where the composer's typed text landed on screen at the last draw, so the input thread can turn a
+/// mouse position into a caret position in the draft.
 ///
 /// The draft is a `Vec<char>` but the screen is a grid of display CELLS, and the two do not line up:
-/// a CJK char or an emoji is two cells wide, a `\n` is painted as a one-cell `↵`, and only a window of
-/// a long draft is on screen at all. So the mapping is published as the column each visible char was
-/// actually painted at — measured by the code that painted it — rather than recomputed on the input
-/// thread from a width function that might disagree.
+/// a CJK char or an emoji is two cells wide, an embedded newline is painted as a blank cell, and a
+/// long draft is wrapped over several rows of which only a window may be on screen. So the mapping is
+/// published as the row and column each visible char was actually painted at — measured by the code
+/// that painted it — rather than recomputed on the input thread from a width function that might
+/// disagree.
 #[derive(Clone, Debug, Default)]
 pub(super) struct InputGeom {
-    /// Screen rect of the `❯ …` row. `width == 0` means nothing has been painted yet: no mapping.
-    pub(crate) row: Rect,
-    /// Draft index of the first char in the visible window.
+    /// Screen rect of the whole text area — every composer row between the framing rules.
+    /// `width == 0` means nothing has been painted yet: no mapping.
+    pub(crate) area: Rect,
+    /// One entry per painted row, top to bottom. Empty until the first frame is drawn.
+    pub(crate) rows: Vec<InputRowGeom>,
+}
+
+/// One painted composer row's mapping: where it is and which draft chars it shows.
+#[derive(Clone, Debug)]
+pub(super) struct InputRowGeom {
+    /// Absolute screen row.
+    pub(crate) y: u16,
+    /// Draft index of the first char on this row.
     pub(crate) start: usize,
-    /// Absolute start column of each visible char, plus one entry for the cell just past the last —
-    /// where a click beyond the end of the text parks the caret. Length is `visible chars + 1`.
+    /// Absolute start column of each char on the row, plus one entry for the cell just past the last —
+    /// where a click beyond the end of the row's text parks the caret. Length is `chars + 1`.
     pub(crate) cols: Vec<u16>,
 }
 
@@ -117,17 +128,29 @@ pub(super) fn input_geom_slot() -> &'static Mutex<InputGeom> {
     SLOT.get_or_init(|| Mutex::new(InputGeom::default()))
 }
 
-/// Draft index a click at column `col` points at, ignoring the row.
+/// Draft index a DRAG at (`col`, `row`) points at, with the row clamped into the box.
 ///
-/// Row-blind on purpose: it backs the DRAG half of a selection, where the pointer routinely leaves the
-/// one-row input box while the user is still selecting inside it. `input_hit` is the row-checked
-/// variant that decides whether a click belongs to the box in the first place.
-pub(crate) fn input_hit_col(col: u16) -> Option<usize> {
+/// Clamped rather than row-checked on purpose: the pointer routinely leaves the box while the user is
+/// still selecting inside it, and a drag that stopped extending the moment it strayed off the last row
+/// would be unusable. Above the box the selection collapses to the start of the first visible row,
+/// below it to the end of the last — which is what dragging past the end of the text means everywhere
+/// else. [`input_hit`] is the row-checked variant that decides whether a CLICK belongs to the box in
+/// the first place.
+pub(crate) fn input_hit_drag(col: u16, row: u16) -> Option<usize> {
     let g = input_geom_slot().lock().unwrap_or_else(|e| e.into_inner());
-    if g.row.width == 0 || g.cols.is_empty() {
+    if g.area.width == 0 {
         return None;
     }
-    Some(hit_index(&g.cols, g.start, col))
+    let first = g.rows.first()?;
+    let last = g.rows.last()?;
+    if row < first.y {
+        return Some(first.start);
+    }
+    if row > last.y {
+        return Some(last.start + last.cols.len().saturating_sub(1));
+    }
+    let r = g.rows.iter().find(|r| r.y == row).unwrap_or(last);
+    Some(hit_index(&r.cols, r.start, col))
 }
 
 /// Which draft char the cell at absolute column `col` belongs to, given a published column map. Pure so
@@ -137,7 +160,7 @@ pub(crate) fn input_hit_col(col: u16) -> Option<usize> {
 /// `cols[i + 1]` is where char `i` ends, so the first char whose end is past the click owns the cell the
 /// click landed on, and the caret goes ON that cell: exactly where the block cursor is then drawn. Both
 /// cells of a double-width char therefore resolve to that char, a click left of the text resolves to the
-/// start of the window, and anything past the end resolves to just after the last visible char.
+/// start of the row, and anything past the end resolves to just after the row's last char.
 pub(super) fn hit_index(cols: &[u16], start: usize, col: u16) -> usize {
     let visible = cols.len().saturating_sub(1);
     for i in 0..visible {
@@ -148,16 +171,15 @@ pub(super) fn hit_index(cols: &[u16], start: usize, col: u16) -> usize {
     start + visible
 }
 
-/// Draft index a click at (`col`, `row`) points at, or `None` when the click is not on the input row.
+/// Draft index a click at (`col`, `row`) points at, or `None` when the click is not on a composer row.
 pub(crate) fn input_hit(col: u16, row: u16) -> Option<usize> {
-    let on_row = {
-        let g = input_geom_slot().lock().unwrap_or_else(|e| e.into_inner());
-        g.row.width > 0
-            && row == g.row.y
-            && col >= g.row.x
-            && col < g.row.x.saturating_add(g.row.width)
-    };
-    on_row.then(|| input_hit_col(col)).flatten()
+    let g = input_geom_slot().lock().unwrap_or_else(|e| e.into_inner());
+    let in_x = g.area.width > 0 && col >= g.area.x && col < g.area.x.saturating_add(g.area.width);
+    if !in_x {
+        return None;
+    }
+    let r = g.rows.iter().find(|r| r.y == row)?;
+    Some(hit_index(&r.cols, r.start, col))
 }
 
 /// Where `draw_footer` last asked ratatui to park the input caret (`frame.set_cursor_position`).

--- a/src/ui/tui/retained/paint.rs
+++ b/src/ui/tui/retained/paint.rs
@@ -1,5 +1,5 @@
 //! Painting one frame: the transcript pane, the selection highlight, the working line, and the
-//! footer with the input row.
+//! footer with the composer — which wraps a long draft down as many rows as it needs.
 //!
 //! Everything here runs on the render thread and is a pure function of `AppState` plus the frame
 //! it is handed — which is what makes the window/caret arithmetic testable without a terminal.
@@ -8,12 +8,19 @@ use super::*;
 
 pub(super) fn draw(frame: &mut Frame<'_>, state: &mut AppState) {
     let area = frame.area();
+    // The composer GROWS DOWNWARD with the draft instead of scrolling one row sideways, so the
+    // footer's height is decided here — before the split — from the wrapped draft. `input_layout` is
+    // pure over `AppState`, so the same call that sizes the box is the one handed to `draw_footer`
+    // to paint it: the two cannot disagree by a row.
+    let layout = input_layout(state, area.width as usize, max_input_rows(area.height));
+    state.input_row_scroll = layout.scroll; // sticky across frames — see `AppState::input_row_scroll`
+    let footer_rows = FOOTER_CHROME_ROWS.saturating_add(layout.rows.len() as u16);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(FOOTER_ROWS)])
+        .constraints([Constraint::Min(1), Constraint::Length(footer_rows)])
         .split(area);
     draw_transcript(frame, chunks[0], state);
-    draw_footer(frame, chunks[1], state);
+    draw_footer(frame, chunks[1], state, &layout);
     // Rects floating ABOVE the transcript this frame. Collected here (rather than inferred later)
     // because only the draw pass knows what was actually painted — the post-draw hyperlink injector
     // writes at absolute coordinates and would otherwise print over them.
@@ -33,6 +40,19 @@ pub(super) fn draw(frame: &mut Frame<'_>, state: &mut AppState) {
     if let Ok(mut slot) = occluders_slot().lock() {
         *slot = occluders;
     }
+}
+
+/// How many text rows the composer may occupy in a terminal `height` rows tall.
+///
+/// The box grows with the draft, but it must never eat the conversation: at least
+/// `MIN_TRANSCRIPT_ROWS` are always left above it, and it never passes `MAX_INPUT_TEXT_ROWS` however
+/// tall the terminal is — past that a pasted wall of text would BE the screen.
+pub(super) fn max_input_rows(height: u16) -> usize {
+    const MIN_TRANSCRIPT_ROWS: u16 = 3;
+    let spare = height
+        .saturating_sub(FOOTER_CHROME_ROWS)
+        .saturating_sub(MIN_TRANSCRIPT_ROWS);
+    spare.clamp(1, MAX_INPUT_TEXT_ROWS) as usize
 }
 
 /// Resolve the transcript scroll for one frame. Pure so it can be unit-tested without a backend.
@@ -315,7 +335,14 @@ pub(super) fn working_line(state: &AppState) -> Vec<(String, Line<'static>)> {
     vec![(plain, Line::from(spans))]
 }
 
-pub(super) fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &mut AppState) {
+/// Paint the footer: the HUD strip, the two framing rules, and the composer's text rows between
+/// them. `layout` is the one computed in [`draw`] — it already decided how tall `area` is.
+pub(super) fn draw_footer(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &mut AppState,
+    layout: &InputLayout,
+) {
     if area.height < FOOTER_ROWS || area.width == 0 {
         // No input row was painted, so retire the click map with it — a stale one would keep answering
         // hit-tests for a row that is no longer on screen.
@@ -324,12 +351,19 @@ pub(super) fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &mut AppStat
         }
         return;
     }
+    // `draw` asked for `3 + layout.rows.len()`, but a Layout under pressure can hand back less than
+    // it asked for — so paint what actually arrived rather than what was requested.
+    let text_rows = layout
+        .rows
+        .len()
+        .min(area.height.saturating_sub(FOOTER_CHROME_ROWS) as usize)
+        .max(1);
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1),
             Constraint::Length(1),
-            Constraint::Length(1),
+            Constraint::Length(text_rows as u16),
             Constraint::Length(1),
         ])
         .split(area);
@@ -392,119 +426,140 @@ pub(super) fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &mut AppStat
     ];
     hud_spans.extend(right_spans);
     frame.render_widget(Paragraph::new(Line::from(hud_spans)), rows[0]);
-    let rule = "─".repeat(width);
+    // Framing rules. When the draft is taller than the box, the rule on that side carries the count
+    // of rows hidden behind it (`↑12` / `↓3`) — without it a scrolled composer is indistinguishable
+    // from a truncated one, which is the very thing this box exists to stop.
+    let hidden_above = layout.scroll;
+    let hidden_below = layout.total.saturating_sub(layout.scroll + text_rows);
     frame.render_widget(
-        Paragraph::new(Line::styled(
-            rule.clone(),
-            Style::default().fg(Color::Indexed(box_accent)),
-        )),
+        Paragraph::new(rule_line(width, box_accent, hidden_above, '↑')),
         rows[1],
     );
-
-    // A quiet right-aligned key hint (`↵ send · Tab complete`) shown only while the draft is empty
-    // and an overlay isn't up — it must never fight the typed text or the `/`-command list for the
-    // row. Reserve its width from the typing budget so the hint and the input never overlap.
-    let hint = if state.input.draft.is_empty() && state.input.overlay.is_none() {
-        "↵ send · Tab complete"
-    } else {
-        ""
-    };
-    let hint_w = if hint.is_empty() {
-        0
-    } else {
-        console::measure_text_width(hint) + 1
-    };
-    // A `[Nimg]` chip when vision attachments are pending (Ctrl-O / dropped files) so the input box
-    // shows the attachment count — matches the classic renderer. Its width is reserved from the
-    // typing budget so it never overlaps the typed text or the caret math.
-    let imgtag = if state.input.images > 0 {
-        format!("[{}img] ", state.input.images)
-    } else {
-        String::new()
-    };
-    let imgtag_w = console::measure_text_width(&imgtag);
-    let type_budget = width.saturating_sub(3 + imgtag_w + hint_w);
-    let row = input_line(state, type_budget);
-    let InputRow {
-        shown,
-        caret_off: cursor_off,
-        start: win_start,
-        cols: char_cols,
-    } = row;
-    state.input_win_start = win_start; // sticky across frames — see `AppState::input_win_start`
-    let shown_w = console::measure_text_width(&shown);
-    // Pad between the typed text and the right-aligned hint. `3` = `❯ ` (2) + one right margin.
-    let hint_gap = width
-        .saturating_sub(3 + imgtag_w + shown_w + hint_w.saturating_sub(1))
-        .max(if hint.is_empty() { 0 } else { 1 });
-    let mut prompt_spans = vec![Span::styled(
-        "❯ ",
-        Style::default()
-            .fg(Color::Indexed(box_accent))
-            .add_modifier(Modifier::BOLD),
-    )];
-    if !imgtag.is_empty() {
-        prompt_spans.push(Span::styled(
-            imgtag,
-            Style::default().fg(Color::Indexed(crate::ui::theme::ACCENT)),
-        ));
-    }
-    prompt_spans.push(Span::styled(shown, Style::default().fg(Color::White)));
-    if !hint.is_empty() {
-        prompt_spans.push(Span::raw(" ".repeat(hint_gap)));
-        prompt_spans.push(Span::styled(
-            hint.to_string(),
-            Style::default().fg(Color::DarkGray),
-        ));
-    }
-    // Cells from the start of the row to the first char of the visible draft window: `❯ ` plus the
-    // `[Nimg]` chip. Both the highlight (row-relative) and the click map (absolute) hang off this.
-    let text_off = 2 + imgtag_w;
-    let mut prompt_line = Line::from(prompt_spans);
-    // A mouse highlight inside the box, painted the same way the transcript paints its own.
-    if let Some((from_cell, to_cell)) = sel_cells(
-        crate::ui::tui::normalized_draft_sel(state.input.sel, state.input.draft.len()),
-        win_start,
-        &char_cols,
-        text_off,
-    ) {
-        reverse_line_cols(&mut prompt_line, from_cell, to_cell);
-    }
-    frame.render_widget(Paragraph::new(prompt_line), rows[2]);
     frame.render_widget(
-        Paragraph::new(Line::styled(
-            rule,
-            Style::default().fg(Color::Indexed(box_accent)),
-        )),
+        Paragraph::new(rule_line(width, box_accent, hidden_below, '↓')),
         rows[3],
     );
+
+    let body_style = if layout.placeholder {
+        Style::default().fg(Color::DarkGray)
+    } else {
+        Style::default().fg(Color::White)
+    };
+    let sel = crate::ui::tui::normalized_draft_sel(state.input.sel, state.input.draft.len());
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(text_rows);
+    for (i, row) in layout.rows.iter().take(text_rows).enumerate() {
+        let mut spans: Vec<Span<'static>> = Vec::with_capacity(5);
+        if i == 0 {
+            spans.push(Span::styled(
+                "❯ ",
+                Style::default()
+                    .fg(Color::Indexed(box_accent))
+                    .add_modifier(Modifier::BOLD),
+            ));
+            // A `[Nimg]` chip when vision attachments are pending (Ctrl-O / dropped files) so the box
+            // shows the attachment count. Its width is baked into `layout.text_off`, so the wrap and
+            // the caret math already know about it.
+            if state.input.images > 0 {
+                spans.push(Span::styled(
+                    format!("[{}img] ", state.input.images),
+                    Style::default().fg(Color::Indexed(crate::ui::theme::ACCENT)),
+                ));
+            }
+        } else {
+            // Continuation rows are indented under the first row's text, so a wrapped prompt reads as
+            // one block instead of a ragged left edge that the `❯` no longer lines up with.
+            spans.push(Span::raw(" ".repeat(layout.text_off)));
+        }
+        spans.push(Span::styled(row.shown.clone(), body_style));
+        // A quiet right-aligned key hint (`↵ send · Tab complete`), only on the first row and only
+        // while the draft is empty — it must never fight typed text for the row.
+        if i == 0 && !layout.hint.is_empty() {
+            let used = layout.text_off + console::measure_text_width(&row.shown);
+            let gap = width
+                .saturating_sub(used + console::measure_text_width(layout.hint))
+                .max(1);
+            spans.push(Span::raw(" ".repeat(gap)));
+            spans.push(Span::styled(
+                layout.hint.to_string(),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        let mut line = Line::from(spans);
+        // A mouse highlight inside the box, painted the same way the transcript paints its own. Each
+        // row clips the draft-index range to its own slice, so a selection spanning several wrapped
+        // rows lights all of them.
+        if !layout.placeholder {
+            if let Some((from_cell, to_cell)) =
+                sel_cells(sel, row.start, &row.cols, layout.text_off)
+            {
+                reverse_line_cols(&mut line, from_cell, to_cell);
+            }
+        }
+        lines.push(line);
+    }
+    frame.render_widget(Paragraph::new(Text::from(lines)), rows[2]);
+
     // Publish where each visible char landed so the input thread can map a click to a caret position.
     if let Ok(mut slot) = input_geom_slot().lock() {
         *slot = InputGeom {
-            row: rows[2],
-            start: win_start,
-            cols: char_cols
+            area: rows[2],
+            rows: layout
+                .rows
                 .iter()
-                .map(|c| {
-                    rows[2]
-                        .x
-                        .saturating_add(text_off as u16)
-                        .saturating_add(*c as u16)
+                .take(text_rows)
+                .enumerate()
+                .map(|(i, r)| InputRowGeom {
+                    y: rows[2].y.saturating_add(i as u16),
+                    start: r.start,
+                    cols: r
+                        .cols
+                        .iter()
+                        .map(|c| {
+                            rows[2]
+                                .x
+                                .saturating_add(layout.text_off as u16)
+                                .saturating_add(*c as u16)
+                        })
+                        .collect(),
                 })
                 .collect(),
         };
     }
+    let (caret_row, caret_col) = layout.caret;
+    let caret_row = caret_row.min(text_rows.saturating_sub(1));
     let cursor_x = rows[2]
         .x
-        .saturating_add(2)
-        .saturating_add(imgtag_w as u16)
-        .saturating_add(cursor_off as u16);
-    let caret = (cursor_x.min(rows[2].right().saturating_sub(1)), rows[2].y);
+        .saturating_add(layout.text_off as u16)
+        .saturating_add(caret_col as u16);
+    let caret = (
+        cursor_x.min(rows[2].right().saturating_sub(1)),
+        rows[2].y.saturating_add(caret_row as u16),
+    );
     frame.set_cursor_position(caret);
     // Publish it so the post-draw hyperlink injector can restore the caret after moving the cursor.
     if let Ok(mut slot) = caret_slot().lock() {
         *slot = Some(caret);
     }
+}
+
+/// One framing rule of the input box. `hidden` > 0 stamps a `↑N` / `↓N` tag into the rule near its
+/// right end — the only place a scrolled composer can report what is off screen without stealing a
+/// cell from the text.
+fn rule_line(width: usize, accent: u8, hidden: usize, arrow: char) -> Line<'static> {
+    let accent_style = Style::default().fg(Color::Indexed(accent));
+    let tag = format!(" {arrow}{hidden} ");
+    let tag_w = console::measure_text_width(&tag);
+    if hidden == 0 || width < tag_w + 6 {
+        return Line::styled("─".repeat(width), accent_style);
+    }
+    Line::from(vec![
+        Span::styled("─".repeat(width - tag_w - 2), accent_style),
+        Span::styled(
+            tag,
+            Style::default().fg(Color::Indexed(crate::ui::theme::MUTED)),
+        ),
+        Span::styled("──".to_string(), accent_style),
+    ])
 }
 
 /// Row cells `[from, to)` that a draft selection covers, clipped to the window actually on screen.
@@ -528,117 +583,228 @@ pub(super) fn sel_cells(
     (to > from).then(|| (text_off + cols[from], text_off + cols[to]))
 }
 
-/// One painted input row: what fits on screen, where the caret goes, and where every visible char
-/// landed. Returned as a struct because the column map is the whole point — see [`InputGeom`].
-pub(super) struct InputRow {
-    /// The text painted after `❯ ` and the `[Nimg]` chip: the window of the draft that fits, behind the
-    /// `↵N · ` paste chip when the draft is many lines. The placeholder text when the draft is empty.
+/// One painted row of the composer: what is on it, which draft chars they are, and where each of
+/// them landed. The column map is the whole point — see [`InputGeom`].
+pub(super) struct InputRowView {
+    /// The text painted after `❯ ` (first row) or the matching indent (continuation rows). An
+    /// embedded newline is painted as a blank cell — the row break itself is the glyph.
     pub(crate) shown: String,
-    /// Display cells from the start of `shown` to the caret.
-    pub(crate) caret_off: usize,
-    /// Draft index of the first char of the visible window (`0` unless a long draft scrolled).
+    /// Draft index of the first char on this row.
     pub(crate) start: usize,
-    /// Display cells from the start of `shown` to the start of visible char `i` — i.e. draft char
-    /// `start + i` — plus one trailing entry for the cell just past the last char. Never empty.
+    /// Display cells from the start of the text area to the start of char `start + i`, plus one
+    /// trailing entry for the cell just past the last char. Never empty.
     pub(crate) cols: Vec<usize>,
 }
 
-pub(super) fn input_line(state: &AppState, budget: usize) -> InputRow {
-    if state.input.draft.is_empty() {
-        let q = if state.input.queued_count > 0 {
-            format!(" · {} queued", state.input.queued_count)
-        } else {
-            String::new()
-        };
-        // Mirror the classic footer: while working, advertise Alt+Enter (steer the RUNNING turn) and
-        // count steers the loop hasn't folded in yet — a steer has no transcript line of its own
-        // until the agent picks it up, so this counter is the only "it landed" feedback.
-        let s = match crate::core::steer::pending() {
-            0 => String::new(),
-            n => format!(" · ⤳{n}"),
-        };
-        let ph = if state.working {
-            format!("Queue · Alt+↵ steers · Esc stops{q}{s}")
-        } else {
-            format!("Type a message · / commands{q}")
-        };
-        // No draft ⇒ no chars to map: `cols` carries only the past-the-end entry, so any click on the
-        // placeholder resolves to caret 0 (which is where an empty draft's caret already is).
-        return InputRow {
-            shown: console::truncate_str(&ph, budget, "…").into_owned(),
-            caret_off: 0,
-            start: 0,
-            cols: vec![0],
-        };
+/// The composer's geometry for one frame: the wrapped draft rows that are on screen, where the caret
+/// sits among them, and how far the window is scrolled.
+///
+/// Computed ONCE per frame in [`draw`] — it is what decides the footer's height — then handed to
+/// [`draw_footer`] to paint. Pure over [`AppState`], so the arithmetic that used to be tangled up
+/// with the widget calls is testable without a terminal.
+pub(super) struct InputLayout {
+    /// Only the rows actually on screen (`scroll..scroll + max_rows` of the wrapped draft).
+    pub(crate) rows: Vec<InputRowView>,
+    /// First wrapped row on screen. `0` unless the draft is taller than the box.
+    pub(crate) scroll: usize,
+    /// Total wrapped rows in the draft, on screen or not.
+    pub(crate) total: usize,
+    /// Caret as `(index into rows, display cells from the start of the text area)`.
+    pub(crate) caret: (usize, usize),
+    /// Cells from the row's left edge to its first text cell: `❯ ` plus any `[Nimg]` chip. The same
+    /// on every row, so wrapped continuations line up under the first one.
+    pub(crate) text_off: usize,
+    /// `rows[0].shown` is the grey placeholder rather than draft text: paint it dim, map no chars.
+    pub(crate) placeholder: bool,
+    /// Right-aligned key hint for the first row. Empty unless the draft is empty.
+    pub(crate) hint: &'static str,
+}
+
+/// Display cells one draft char occupies. A newline owns a cell of its own (painted blank) so a
+/// click at the end of a line can park the caret BEFORE the break instead of at the start of the
+/// next line, and so a selection that spans it shows the break it is about to copy.
+fn draft_cellw(c: char) -> usize {
+    // The whole draft is re-wrapped on every frame, so the common case must not allocate:
+    // printable ASCII is width 1 by definition, and only the rest is worth a measuring call.
+    if c == '\n' || c == ' ' || c.is_ascii_graphic() {
+        return 1;
     }
-    // Khi draft có ≥5 dòng (paste lớn), vẫn hiện prefix compact `↵N ·` để báo hiệu,
-    // nhưng KHÔNG ẩn toàn bộ text — window quanh cursor vẫn hiện bình thường để người
-    // dùng thấy những gì vừa gõ thêm. Trước đây trả về chip cứng nên text bị ẩn.
-    let nlines = state.input.draft.iter().filter(|&&c| c == '\n').count() + 1;
-    let paste_prefix = if nlines >= 5 {
-        format!("↵{nlines} · ")
+    console::measure_text_width(&c.to_string()).max(1)
+}
+
+/// Lay a draft out over as many rows as it needs, at `width` display cells per row.
+///
+/// Two things end a row: an embedded newline (Shift+Enter, or a pasted block) and running out of
+/// width. The width break prefers the last space on the row, so a long prompt wraps as prose instead
+/// of being guillotined mid-word; a single word wider than the box still breaks hard, because the
+/// alternative is a row that never ends.
+///
+/// Always returns at least one row, and always ends one: a draft ending in a newline gets the empty
+/// trailing row the caret is sitting on.
+fn wrap_draft(draft: &[char], width: usize) -> Vec<InputRowView> {
+    let width = width.max(1);
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let (mut i, mut start, mut used) = (0usize, 0usize, 0usize);
+    // Draft index just AFTER the last space on the row being built — the preferred break point.
+    let mut last_space: Option<usize> = None;
+    while i < draft.len() {
+        let c = draft[i];
+        let cw = draft_cellw(c);
+        if used + cw > width && i > start {
+            let brk = last_space.filter(|b| *b > start && *b < i).unwrap_or(i);
+            ranges.push((start, brk));
+            start = brk;
+            used = 0;
+            last_space = None;
+            // Re-lay from the break: chars moved off the full row have to be measured again on the
+            // fresh one. `brk > start` held before the assignment, so this always advances.
+            i = brk;
+            continue;
+        }
+        used += cw;
+        i += 1;
+        if c == '\n' {
+            ranges.push((start, i));
+            start = i;
+            used = 0;
+            last_space = None;
+        } else if c == ' ' {
+            last_space = Some(i);
+        }
+    }
+    ranges.push((start, draft.len()));
+    ranges
+        .into_iter()
+        .map(|(s, e)| row_view(draft, s, e))
+        .collect()
+}
+
+/// Measure one row range into the map the painter and the hit-test both read.
+fn row_view(draft: &[char], start: usize, end: usize) -> InputRowView {
+    let mut shown = String::new();
+    let mut cols = Vec::with_capacity(end.saturating_sub(start) + 1);
+    let mut used = 0usize;
+    for &c in &draft[start..end] {
+        cols.push(used);
+        shown.push(if c == '\n' { ' ' } else { c });
+        used += draft_cellw(c);
+    }
+    // One entry past the last char, so a click beyond the text has a cell to land on.
+    cols.push(used);
+    InputRowView { shown, start, cols }
+}
+
+/// Which row the caret belongs to. A row spanning `[start, end)` owns carets `[start, end)`; the
+/// caret at the very end of the draft belongs to the last row, which is why the fallback is not an
+/// error.
+fn caret_row_of(rows: &[InputRowView], cursor: usize) -> usize {
+    for (i, r) in rows.iter().enumerate() {
+        if cursor < r.start + r.cols.len().saturating_sub(1) {
+            return i;
+        }
+    }
+    rows.len().saturating_sub(1)
+}
+
+/// The grey line shown in place of the draft when there is nothing typed.
+fn placeholder_text(state: &AppState) -> String {
+    let q = if state.input.queued_count > 0 {
+        format!(" · {} queued", state.input.queued_count)
     } else {
         String::new()
     };
-    let prefix_w = console::measure_text_width(&paste_prefix);
-    let cursor = state.input.cursor.min(state.input.draft.len());
-    // The input box is a single physical row, so render an embedded newline as a visible `↵`
-    // glyph (width 1) rather than a raw `\n` that ratatui can't lay out on one line.
-    let disp = |c: char| -> char {
-        if c == '\n' {
-            '↵'
-        } else {
-            c
-        }
+    // Mirror the classic footer: while working, advertise Alt+Enter (steer the RUNNING turn) and
+    // count steers the loop hasn't folded in yet — a steer has no transcript line of its own
+    // until the agent picks it up, so this counter is the only "it landed" feedback.
+    let s = match crate::core::steer::pending() {
+        0 => String::new(),
+        n => format!(" · ⤳{n}"),
     };
-    let cellw = |c: char| console::measure_text_width(&disp(c).to_string()).max(1);
-    // Budget for the text window shrinks by the paste prefix (e.g. `↵12 · `) so both fit on one row.
-    let text_budget = budget.saturating_sub(prefix_w);
-    let draft = &state.input.draft;
-    // ── Sticky window ──────────────────────────────────────────────────────────────────────────────
-    // Start from where the window was last frame and move it only as far as the caret forces. One cell
-    // is held back from the right edge so the block caret has somewhere to sit at the end of the text.
-    let cap = text_budget.saturating_sub(1);
-    let mut start = state.input_win_start.min(cursor);
-    // Caret past the right edge (typing, or a jump to the end) → scroll right until it fits.
-    let mut to_caret: usize = draft[start..cursor].iter().map(|&c| cellw(c)).sum();
-    while to_caret > cap && start < cursor {
-        to_caret -= cellw(draft[start]);
-        start += 1;
+    if state.working {
+        format!("Queue · Alt+↵ steers · Esc stops{q}{s}")
+    } else {
+        format!("Type a message · / commands{q}")
     }
-    // Tail no longer fills the window (after deleting, or a wider terminal) → pull it back left, so a
-    // scrolled draft never shows dead space on the right with text hidden off the left.
-    let mut tail: usize = draft[start..].iter().map(|&c| cellw(c)).sum();
-    while start > 0 {
-        let cw = cellw(draft[start - 1]);
-        if tail + cw > cap {
-            break;
-        }
-        tail += cw;
-        start -= 1;
+}
+
+/// Wrap the draft, place the caret in it, and pick the window of rows to show.
+///
+/// `width` is the full footer width; `max_rows` the tallest the box may grow (see
+/// [`max_input_rows`]). Past that the window SCROLLS by rows — but only as far as the caret forces
+/// it. Re-deriving the window from the caret every frame would pin the caret to the bottom row, so a
+/// glance back up a long paste would snap away the moment anything repainted.
+pub(super) fn input_layout(state: &AppState, width: usize, max_rows: usize) -> InputLayout {
+    let max_rows = max_rows.max(1);
+    let imgtag_w = if state.input.images > 0 {
+        console::measure_text_width(&format!("[{}img] ", state.input.images))
+    } else {
+        0
+    };
+    // `❯ ` plus the chip. Reserved on continuation rows too, so wrapped text stays in one column.
+    let text_off = 2 + imgtag_w;
+
+    if state.input.draft.is_empty() {
+        let hint = if state.input.overlay.is_none() {
+            "↵ send · Tab complete"
+        } else {
+            ""
+        };
+        let hint_w = if hint.is_empty() {
+            0
+        } else {
+            console::measure_text_width(hint) + 1
+        };
+        let budget = width.saturating_sub(text_off + hint_w + 1);
+        // No draft ⇒ no chars to map: `cols` carries only the past-the-end entry, so any click on the
+        // placeholder resolves to caret 0 (which is where an empty draft's caret already is).
+        return InputLayout {
+            rows: vec![InputRowView {
+                shown: console::truncate_str(&placeholder_text(state), budget, "…").into_owned(),
+                start: 0,
+                cols: vec![0],
+            }],
+            scroll: 0,
+            total: 1,
+            caret: (0, 0),
+            text_off,
+            placeholder: true,
+            hint,
+        };
     }
-    let mut shown = String::new();
-    let mut cols = Vec::with_capacity(text_budget + 1);
-    let mut used = 0usize;
-    for &c in &draft[start..] {
-        let cw = cellw(c);
-        if used + cw > text_budget {
-            break;
-        }
-        cols.push(prefix_w + used);
-        shown.push(disp(c));
-        used += cw;
+
+    // One cell is held back on the right so the block caret has somewhere to sit at the end of a full
+    // row, and so wrapped text never touches the frame edge.
+    let wrap_w = width.saturating_sub(text_off + 1).max(1);
+    let rows = wrap_draft(&state.input.draft, wrap_w);
+    let cursor = state.input.cursor.min(state.input.draft.len());
+    let caret_row = caret_row_of(&rows, cursor);
+    let total = rows.len();
+
+    // Sticky window: it moves only as far as the caret forces it.
+    let mut scroll = state.input_row_scroll.min(total.saturating_sub(max_rows));
+    if caret_row < scroll {
+        scroll = caret_row;
+    } else if caret_row >= scroll + max_rows {
+        scroll = caret_row + 1 - max_rows;
     }
-    // One entry past the last visible char, so a click beyond the text has a cell to land on.
-    cols.push(prefix_w + used);
-    // Re-measure the caret against the window that was actually chosen: the pull-back loop above can
-    // move `start` left after `to_caret` was computed.
-    let caret: usize = draft[start..cursor].iter().map(|&c| cellw(c)).sum();
-    // Prepend the paste-count prefix and offset the cursor position past it.
-    InputRow {
-        shown: format!("{paste_prefix}{shown}"),
-        caret_off: prefix_w + caret,
-        start,
-        cols,
+    let caret_col = rows
+        .get(caret_row)
+        .map(|r| {
+            let within = cursor.saturating_sub(r.start);
+            r.cols
+                .get(within)
+                .copied()
+                .unwrap_or_else(|| r.cols.last().copied().unwrap_or(0))
+        })
+        .unwrap_or(0);
+    let visible: Vec<InputRowView> = rows.into_iter().skip(scroll).take(max_rows).collect();
+    InputLayout {
+        caret: (caret_row.saturating_sub(scroll), caret_col),
+        rows: visible,
+        scroll,
+        total,
+        text_off,
+        placeholder: false,
+        hint: "",
     }
 }

--- a/src/ui/tui/retained/tests.rs
+++ b/src/ui/tui/retained/tests.rs
@@ -54,114 +54,135 @@ fn keep_sgr_drops_cursor_moves_but_keeps_colour() {
     assert_eq!(got, "ok\x1b[31mred\x1b[0m\nnext");
 }
 
-#[test]
-fn short_multiline_draft_stays_inline() {
-    let mut state = AppState::new("intro", "status");
-    state.input.draft = "x\n".chars().collect();
-    state.input.cursor = state.input.draft.len();
-
-    let InputRow {
-        shown,
-        caret_off: caret,
-        ..
-    } = input_line(&state, 40);
-
-    assert_eq!(shown, "x↵", "a short Shift+Enter draft is shown inline");
-    assert_eq!(caret, 2, "caret advances over the visible newline glyph");
-    assert!(
-        !shown.contains("lines pasted"),
-        "short text must not look like a paste chip"
-    );
-}
-
-#[test]
-fn large_multiline_draft_uses_paste_chip() {
-    // Fix: paste lớn vẫn hiện prefix compact `↵N ·` + text quanh cursor, KHÔNG ẩn toàn bộ
-    // draft bằng chip cứng. Người dùng vừa paste vừa gõ thêm phải thấy những gì họ gõ.
-    let mut state = AppState::new("intro", "status");
-    state.input.draft = "a\nb\nc\nd\ne".chars().collect();
-    state.input.cursor = state.input.draft.len();
-
-    let shown = input_line(&state, 40).shown;
-
-    // Phải có prefix báo số dòng.
-    assert!(
-        shown.starts_with("↵5 · "),
-        "paste prefix missing: {shown:?}"
-    );
-    // Text thật (ký tự cuối draft là 'e') vẫn hiện sau prefix.
-    assert!(
-        shown.contains('e'),
-        "draft text must follow the prefix: {shown:?}"
-    );
-}
-
-/// A draft of `text` with the caret at `cursor` and the window last drawn from `win_start`.
-fn input_state(text: &str, cursor: usize, win_start: usize) -> AppState {
+/// A draft of `text` with the caret at `cursor` and the box scrolled to wrapped row `row_scroll`.
+fn input_state(text: &str, cursor: usize, row_scroll: usize) -> AppState {
     let mut state = AppState::new("intro", "status");
     state.input.draft = text.chars().collect();
     state.input.cursor = cursor;
-    state.input_win_start = win_start;
+    state.input_row_scroll = row_scroll;
     state
 }
 
-#[test]
-fn window_stays_put_while_the_caret_moves_inside_it() {
-    // THE BUG: the window used to be re-derived from the caret every frame, which pinned the caret
-    // to the right edge — so ←, or a click, scrolled the whole line under a stationary cursor and
-    // you could never land on the char you aimed at. Same draft, caret walked back one char: the
-    // window must not move.
-    let long: String = ('a'..='z').cycle().take(80).collect();
-    let end = input_line(&input_state(&long, 80, 0), 20);
-    assert!(
-        end.start > 0,
-        "a draft 4x the box must scroll at all: {:?}",
-        end.shown
-    );
-    assert_eq!(
-        end.caret_off, 19,
-        "typing at the end keeps the caret at the right edge"
-    );
-
-    let back = input_line(&input_state(&long, 79, end.start), 20);
-    assert_eq!(
-        back.start, end.start,
-        "moving the caret INSIDE the window must not scroll the text"
-    );
-    assert_eq!(back.caret_off, 18, "the caret moved, not the text");
+/// Full text of a laid-out box, rows joined by `|` — enough to assert where the breaks landed.
+fn joined(layout: &InputLayout) -> String {
+    layout
+        .rows
+        .iter()
+        .map(|r| r.shown.clone())
+        .collect::<Vec<_>>()
+        .join("|")
 }
 
 #[test]
-fn window_follows_the_caret_off_either_edge() {
+fn a_long_draft_wraps_downward_instead_of_scrolling_away() {
+    // THE BUG: the box was ONE row, so everything before the window slid off the left and could not
+    // be read back or copied. A draft wider than the box must now occupy more rows, with every char
+    // of it still on screen.
     let long: String = ('a'..='z').cycle().take(80).collect();
-    // Caret left of the window (Home, or a click after scrolling) → re-anchor on the caret.
-    let home = input_line(&input_state(&long, 0, 60), 20);
-    assert_eq!(home.start, 0);
-    assert_eq!(home.caret_off, 0);
-    // Caret past the right edge (End) → scroll so it fits, one cell short of the width for the
-    // caret cell itself.
-    let end = input_line(&input_state(&long, 80, 0), 20);
-    assert_eq!(end.start, 80 - 19);
-    // Window scrolled but the draft now fits → pull back so no dead space shows on the right.
-    let short = input_line(&input_state("abc", 3, 40), 20);
-    assert_eq!(short.start, 0, "a short draft is never scrolled");
-    assert_eq!(short.shown, "abc");
+    // width 24 → text area 24 - 2 (`❯ `) - 1 (caret margin) = 21 cells per row.
+    let layout = input_layout(&input_state(&long, 80, 0), 24, 10);
+    assert!(layout.rows.len() > 1, "80 chars at 21 cells must wrap");
+    assert_eq!(layout.total, 4, "80 chars / 21 cells = 4 rows");
+    let painted: String = layout.rows.iter().map(|r| r.shown.clone()).collect();
+    assert_eq!(painted, long, "every char stays on screen, in order");
+    assert_eq!(layout.scroll, 0, "4 rows fit under a 10-row cap");
 }
 
 #[test]
-fn column_map_covers_every_visible_char_and_one_past_the_end() {
-    let row = input_line(&input_state("abc", 3, 0), 20);
+fn wrapping_breaks_on_spaces_but_still_splits_a_long_word() {
+    // Prose wraps at the last space, so a wrapped prompt reads as prose. Width 11 leaves 8 cells of
+    // text (11 - 2 for `❯ ` - 1 for the caret margin), so each word lands on its own row.
+    let layout = input_layout(&input_state("hello world again", 0, 0), 11, 10);
+    assert_eq!(joined(&layout), "hello |world |again");
+    // A single word wider than the box has no space to break on — it breaks hard rather than
+    // producing a row that never ends.
+    let layout = input_layout(&input_state("aaaaaaaaaaaaaaaa", 0, 0), 14, 10);
+    assert_eq!(joined(&layout), "aaaaaaaaaaa|aaaaa");
+}
+
+#[test]
+fn embedded_newlines_start_a_new_row() {
+    // Shift+Enter and pasted blocks break rows on their own, whatever the width. The newline keeps a
+    // cell of its own (painted blank) so a click at the end of a line lands BEFORE the break.
+    let layout = input_layout(&input_state("a\nb\nc", 5, 0), 40, 10);
+    assert_eq!(layout.rows.len(), 3);
+    assert_eq!(joined(&layout), "a |b |c");
+    assert_eq!(layout.rows[1].start, 2, "row 2 starts after the first \\n");
+    // A draft ending in a newline gets the empty row the caret is sitting on.
+    let layout = input_layout(&input_state("a\n", 2, 0), 40, 10);
+    assert_eq!(layout.rows.len(), 2);
+    assert_eq!(layout.caret, (1, 0), "caret on the fresh empty row");
+}
+
+#[test]
+fn the_caret_lands_on_the_row_that_owns_it() {
+    let layout = input_layout(&input_state("abc\ndef", 5, 0), 40, 10);
+    assert_eq!(layout.caret, (1, 1), "second row, one cell in");
+    // End of the draft: the last row, past its last char.
+    let layout = input_layout(&input_state("abc\ndef", 7, 0), 40, 10);
+    assert_eq!(layout.caret, (1, 3));
+    // On the newline itself: still the END of the first row, not the start of the second.
+    let layout = input_layout(&input_state("abc\ndef", 3, 0), 40, 10);
+    assert_eq!(layout.caret, (0, 3));
+}
+
+#[test]
+fn the_box_scrolls_by_rows_only_once_it_hits_its_ceiling() {
+    let many: String = (0..8).map(|i| format!("line{i}\n")).collect();
+    let end = many.chars().count();
+    // 9 wrapped rows (8 newline-terminated + the trailing empty one), box capped at 3.
+    let layout = input_layout(&input_state(&many, end, 0), 40, 3);
+    assert_eq!(layout.total, 9);
+    assert_eq!(layout.rows.len(), 3, "never taller than the cap");
+    assert_eq!(layout.scroll, 6, "the caret's row is the bottom one");
+    assert_eq!(layout.caret.0, 2);
+    // Caret walked back above the window → the window follows it up.
+    let layout = input_layout(&input_state(&many, 0, 6), 40, 3);
+    assert_eq!(layout.scroll, 0);
+    // Caret INSIDE the window → the window does not move, so reading back a long paste is stable.
+    let layout = input_layout(&input_state(&many, end - 1, 6), 40, 3);
     assert_eq!(
-        row.cols,
+        layout.scroll, 6,
+        "a caret already on screen must not scroll"
+    );
+}
+
+#[test]
+fn max_input_rows_leaves_the_transcript_room() {
+    assert_eq!(max_input_rows(40), 10, "capped by MAX_INPUT_TEXT_ROWS");
+    assert_eq!(max_input_rows(10), 4, "10 - 3 chrome - 3 transcript");
+    assert_eq!(max_input_rows(6), 1, "a tiny terminal still gets one row");
+    assert_eq!(max_input_rows(1), 1, "never zero");
+}
+
+#[test]
+fn an_empty_draft_is_one_placeholder_row() {
+    let layout = input_layout(&AppState::new("intro", "status"), 60, 10);
+    assert_eq!(layout.rows.len(), 1);
+    assert!(layout.placeholder);
+    assert!(layout.rows[0].shown.starts_with("Type a message"));
+    assert_eq!(
+        layout.rows[0].cols,
+        vec![0],
+        "the placeholder maps no chars, so a click on it parks the caret at 0"
+    );
+    assert_eq!(layout.hint, "↵ send · Tab complete");
+}
+
+#[test]
+fn column_map_covers_every_char_on_the_row_and_one_past_the_end() {
+    let layout = input_layout(&input_state("abc", 3, 0), 40, 10);
+    assert_eq!(
+        layout.rows[0].cols,
         vec![0, 1, 2, 3],
         "3 chars + the past-the-end cell"
     );
     // A wide char takes two cells, so the map is not a 1:1 index → column relation. `♥` is width 1;
     // use a CJK char, which every wcwidth table agrees is 2.
-    let wide = input_line(&input_state("a漢b", 3, 0), 20);
-    assert_eq!(wide.cols, vec![0, 1, 3, 4]);
+    let wide = input_layout(&input_state("a漢b", 3, 0), 40, 10);
+    assert_eq!(wide.rows[0].cols, vec![0, 1, 3, 4]);
     // Both cells of the wide char resolve to it; past the end lands after the last char.
-    let cols: Vec<u16> = wide.cols.iter().map(|c| *c as u16).collect();
+    let cols: Vec<u16> = wide.rows[0].cols.iter().map(|c| *c as u16).collect();
     assert_eq!(hit_index(&cols, 0, 1), 1, "left cell of 漢");
     assert_eq!(
         hit_index(&cols, 0, 2),
@@ -175,6 +196,31 @@ fn column_map_covers_every_visible_char_and_one_past_the_end() {
         "far right of the row → end of text"
     );
     assert_eq!(hit_index(&cols, 0, 0), 0, "first cell");
+}
+
+#[test]
+fn a_selection_spanning_wrapped_rows_lights_every_row_it_covers() {
+    // The highlight is one range of DRAFT indices but several rows of cells, so each row clips it to
+    // its own slice. Without that, only the row the drag started on would light up.
+    let layout = input_layout(&input_state("hello world again", 0, 0), 11, 10);
+    // Rows: "hello " (0..6), "world " (6..12), "again" (12..17). Select "lo world ag".
+    let sel = Some((3usize, 14usize));
+    let off = layout.text_off;
+    assert_eq!(
+        sel_cells(sel, layout.rows[0].start, &layout.rows[0].cols, off),
+        Some((off + 3, off + 6)),
+        "from the anchor to the end of the first row"
+    );
+    assert_eq!(
+        sel_cells(sel, layout.rows[1].start, &layout.rows[1].cols, off),
+        Some((off, off + 6)),
+        "the whole middle row"
+    );
+    assert_eq!(
+        sel_cells(sel, layout.rows[2].start, &layout.rows[2].cols, off),
+        Some((off, off + 2)),
+        "up to the cursor on the last row"
+    );
 }
 
 #[test]
@@ -969,4 +1015,61 @@ fn verify_line_reads_green_success() {
     };
     let row = plain(&render_verify_line(&v, 80));
     assert_eq!(row, "✓ cargo check — 0 errors · verify gate passed");
+}
+
+/// Paint one whole frame into an in-memory terminal and read the rows back as plain text. Wraps the
+/// only end-to-end check there is that the footer's height, its rules and its text rows agree — the
+/// layout arithmetic being right is no use if the widgets are handed the wrong rects.
+fn painted_rows(state: &mut AppState, w: u16, h: u16) -> Vec<String> {
+    let mut term = Terminal::new(ratatui::backend::TestBackend::new(w, h)).unwrap();
+    term.draw(|f| draw(f, state)).unwrap();
+    let buf = term.backend().buffer().clone();
+    (0..h)
+        .map(|y| {
+            let row: String = (0..w).map(|x| buf[(x, y)].symbol()).collect();
+            row.trim_end().to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn a_long_prompt_is_painted_down_the_screen_not_off_the_side() {
+    // THE BUG this box exists to fix: a prompt longer than one row scrolled sideways, so most of
+    // what you typed was hidden and there was no way to read it back — or select it to copy.
+    let mut state = AppState::new("intro", "status");
+    let prompt = "hay giup toi viet mot doan van rat dai de kiem tra xem hop nhap co xuong dong";
+    state.input.draft = prompt.chars().collect();
+    state.input.cursor = state.input.draft.len();
+    let rows = painted_rows(&mut state, 40, 12);
+    assert_eq!(rows[8], "❯ hay giup toi viet mot doan van rat");
+    assert_eq!(rows[9], "  dai de kiem tra xem hop nhap co");
+    assert_eq!(rows[10], "  xuong dong");
+    assert_eq!(rows[7], "─".repeat(40), "top rule sits above the text rows");
+    assert_eq!(rows[11], "─".repeat(40), "bottom rule closes the box");
+    // Nothing is dropped: the painted rows re-join into the prompt exactly.
+    let joined = rows[8..=10]
+        .iter()
+        .map(|r| r.trim_start_matches("❯ ").trim_start())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(joined, prompt);
+}
+
+#[test]
+fn a_draft_taller_than_the_box_stops_growing_and_says_what_is_hidden() {
+    // The box grows, but not without limit: the transcript keeps its floor, and the rule reports the
+    // rows behind it so a capped composer never reads as a truncated one.
+    let mut state = AppState::new("intro", "status");
+    let many: String = (0..14).map(|i| format!("dong so {i}\n")).collect();
+    state.input.draft = many.chars().collect();
+    state.input.cursor = 30;
+    let rows = painted_rows(&mut state, 40, 16);
+    assert_eq!(rows[5], "❯ dong so 0");
+    assert_eq!(rows[14], "  dong so 9", "10 text rows is the ceiling");
+    assert!(
+        rows[15].ends_with("↓5 ──"),
+        "the bottom rule counts the hidden rows: {:?}",
+        rows[15]
+    );
+    assert_eq!(rows[0], "intro", "the transcript keeps its floor");
 }


### PR DESCRIPTION
Two changes, then the release cut.

## The composer wraps a long prompt down instead of hiding it

The input box was ONE physical row. A prompt wider than it scrolled sideways, so everything left of the window was off screen — unreadable, and (the hit-test being single-row) unselectable, which left `Ctrl-C` taking **all** of it as the only way to get your own text back.

It now grows downward:

```
❯ hay giup toi viet mot doan van rat
  dai de kiem tra xem hop nhap co
  xuong dong
────────────────────────────────────────
```

- width breaks prefer the last space on the row, so a wrapped prompt reads as prose; a word wider than the box still breaks hard
- an embedded newline keeps a blank cell of its own, so a click at the end of a line parks the caret **before** the break
- the box stops at 10 rows and never leaves the transcript under 3; past that it scrolls by row (stickily — a caret already on screen never drags the window) and the framing rules carry the hidden count (`↑12` / `↓3`)
- the click map is multi-row, so a drag selects **across** wrapped rows and the copy comes back with its newlines intact — the point of the change
- ↑/↓ walk the rows of a multi-line draft before they mean history recall

`input_layout` is pure over `AppState` and is called once per frame in `draw`, before the layout split — the value that sizes the footer is the one handed to `draw_footer`, so they cannot disagree by a row.

## `aizen agent --image <PATH>`

Vision was REPL-only (drag-drop, `Ctrl-O`), so a front-end driving the headless entry point could describe a picture but never show one. The flag inlines a PNG/JPEG/GIF/WebP (≤ 8 MB) into the first user message as an `image_url` data part — the same wire shape the REPL produces. Files are read **before** the endpoint is resolved (a mistyped path costs a failed open, not a billed request), and an unreadable path ends the run rather than being skipped: an attachment that silently vanished would yield a confident answer about an image nothing ever sent.

Omit the flag and the request is byte-identical to one from a core that never had it.

## Release

`Cargo.toml` 0.6.5 → 0.6.6, `CHANGELOG.md` `[Unreleased]` cut to `## [0.6.6] — 2026-08-21`.

Worth knowing: the manifest sat at 0.6.5 from that release until now, so every build cut from `dev` in between also reported `aizen 0.6.5`. This is the first bump since.

## Testing

- `cargo test --bin aizen` — 1721 passed, 0 failed
- 12 new tests: 10 unit tests over `input_layout` (wrap, word breaks, newlines, caret row, sticky row-scroll, the row cap) and 2 that paint a whole frame into a `TestBackend` and read the rows back
- `cargo fmt`, `cargo clippy` — no new warnings in the changed files
- installed the release build locally and used it
