### PR TITLE
release: 0.6.6 — the prompt you typed stays where you can read it

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Who must review what. With "Require review from Code Owners" enabled on `main` and `dev`, a pull
+# request cannot merge until the owner listed here has approved it — the catch-all covers the whole
+# tree, and the entries below exist to make ownership of the expensive-to-get-wrong areas explicit
+# rather than merely inherited.
+
+*                            @dawnofcd
+
+# Licensing and governance: changing these changes what every downstream user is allowed to do.
+# `LICENSE` is a byte-exact copy of Apache-2.0 — reformatting it breaks license detection.
+/LICENSE                     @dawnofcd
+/NOTICE                      @dawnofcd
+/CLA.md                      @dawnofcd
+
+# CI, release automation and the branch rules themselves.
+/.github/                    @dawnofcd
+
+# The safety boundary: every model-influenced process is spawned through here.
+/src/sandbox/                @dawnofcd
+
+# Self-update points users at a release channel — a wrong repo slug ships them someone else's binary.
+/src/features/update.rs      @dawnofcd
+/install.ps1                 @dawnofcd
+/install.sh                  @dawnofcd

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,13 @@
 
 Closes #
 
+## Base branch
+
+<!-- Feature and fix PRs target `dev`. Only a release/* or hotfix/* branch targets `main`.
+     See docs/BRANCHING.md. -->
+
+- [ ] This PR targets **dev** (or it is a release/hotfix PR targeting `main`).
+
 ## Type of change
 
 - [ ] Bug fix (regression test included)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: ci
 
-# Build + test on every push to main and every pull request, so contributors get fast feedback and
-# a PR can't merge red. Pure-Rust single static binary — no C toolchain needed. Uses the built-in
-# GITHUB_TOKEN only; runs on forks' PRs too (pull_request, not pull_request_target — no secrets
-# exposed to untrusted code).
+# Build + test on every push to main or dev and on every pull request, so contributors get fast
+# feedback and a PR can't merge red. Pure-Rust single static binary — no C toolchain needed. Uses
+# the built-in GITHUB_TOKEN only; runs on forks' PRs too (pull_request, not pull_request_target —
+# no secrets exposed to untrusted code).
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ development log lives in that monorepo's history.
 
 ## [Unreleased]
 
+## [0.6.6] — 2026-08-21
+
 ### Added
+- **The composer wraps a long prompt down instead of hiding it.** The input box was ONE physical
+  row: a prompt wider than it scrolled sideways, so everything left of the window was off screen —
+  unreadable, and (the hit-test being single-row) unselectable, which left Ctrl-C taking ALL of it
+  as the only way to get your own text back. It now grows downward. Width breaks prefer the last
+  space on the row so a wrapped prompt reads as prose, a word wider than the box still breaks hard,
+  and an embedded newline keeps a blank cell of its own so a click at the end of a line parks the
+  caret BEFORE the break rather than at the start of the next. The box stops at 10 rows and never
+  leaves the transcript under 3; past that it scrolls by row — stickily, so a caret already on
+  screen never drags the window — and the framing rules carry the hidden-row count (`↑12` / `↓3`),
+  because a capped box that said nothing would read as a truncated one. The click map is multi-row,
+  so a drag now selects across wrapped rows and the copy comes back with its newlines intact. ↑/↓
+  walk the rows of a multi-line draft before they mean history recall: the first ↑ inside a pasted
+  block used to swap the whole block out for the last message.
+- **`aizen agent --image <PATH>`.** Vision was REPL-only — drag a file onto the window, or Ctrl-O
+  for a screenshot — so a front-end driving the headless entry point could describe a picture but
+  never show one. The flag inlines a PNG/JPEG/GIF/WebP (≤ 8 MB) into the first user message as an
+  `image_url` data part, the same wire shape the REPL's attach paths produce; repeat it for more
+  than one. The files are read **before** the endpoint is resolved, so a mistyped path costs a
+  failed open rather than a billed request, and a path that is not a readable image ends the run
+  instead of being skipped: this is the scripting and CI entry point, and an attachment that
+  silently vanished would yield a confident answer about an image nothing ever sent. Note the
+  deliberate difference from the REPL, where a typed line lifts only real image paths and leaves
+  anything else as prose — right for something a human typed, wrong for a flag. Omit it and the
+  request is byte-identical to one from a core that never had it.
 - **`aizen config set` reaches the twelve keys it could not.** `update_check`, `skill_registry`,
   `max_tokens`, `prompt_cache`, `prompt_tier`, `eager_tools`, `self_review`,
   `max_parallel_subagents`, `workflow_tool`, `embed_model`, `timemachine_keep_safety` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,13 @@ Requirements:
 
 ## Making a change
 
-1. **Fork** the repo and create a branch off `main` (`git checkout -b my-fix`).
+1. **Fork** the repo and create a branch off `dev`, the integration branch (`git switch -c my-fix public/dev`). `main` is the release line and only accepts release/hotfix PRs — see [docs/BRANCHING.md](docs/BRANCHING.md).
 2. Make your change. Match the surrounding code — naming, comment density, error handling.
 3. **Add or update tests.** New behavior needs a test; a bug fix needs a test that would have caught it.
 4. Run `cargo test --bin aizen` and make sure it's **green**.
 5. Run `cargo fmt` and `cargo clippy` and clear anything you introduced.
 6. Commit with a clear message (imperative mood: "fix scrollbar drift", not "fixed stuff").
-7. Push and open a PR against `aizen-stack/aizen:main`. Fill in the PR template.
+7. Push and open a PR against `aizen-stack/aizen:dev`. Fill in the PR template.
 
 ## What gets merged
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "aizen"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aizen"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 description = "Aizen first-party agentic coding CLI — OpenAI-compatible, hermes-style provider-agnostic API client"
 license = "Apache-2.0"

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,104 @@
+# Branching and release process
+
+The rules a change follows from a working tree to a published binary. They are enforced by GitHub
+branch protection and CI, not by memory — if something here is only a convention, it says so.
+
+## The two remotes (read this first)
+
+| Remote | URL | Role |
+|---|---|---|
+| `public` | `github.com/aizen-stack/aizen` | **the live line.** `main`, `dev`, every PR, every release |
+| `origin` | `github.com/dawnofcd/Aizen_agent` (private) | historical private mirror — **divergent history** |
+
+`origin/main` and `public/main` do not share an ancestor any more. Never merge one into the other:
+a cross-merge would replay years of unrelated history into the live line. All work described below
+happens on `public`.
+
+## Branches
+
+| Branch | Cut from | Merges into | Protected |
+|---|---|---|---|
+| `main` | — | — | yes — release line, always tagged and shippable |
+| `dev` | `main` | `main` (via a release branch) | yes — integration line, always green |
+| `feat/*`, `fix/*`, `chore/*`, `docs/*`, `refactor/*` | `dev` | `dev` | no |
+| `release/vX.Y.Z` | `dev` | `main` | no |
+| `hotfix/vX.Y.Z` | `main` | `main` **and** `dev` | no |
+
+`main` only ever moves through a release or a hotfix PR. Day-to-day work never targets it.
+
+## Everyday flow
+
+```bash
+git fetch public
+git switch -c fix/short-description public/dev     # always cut from dev, never from a stale local
+# … work, commit …
+cargo fmt && cargo clippy && cargo test --bin aizen   # all three green BEFORE you push
+git push -u public fix/short-description
+gh pr create --base dev --fill                     # base is dev — a PR into main will be rejected
+```
+
+A PR merges when: CI is green on every OS in the matrix, the CLA check passes, and the code owner
+has approved. Squash-merge is the default so `dev` reads as one commit per change; a merge commit is
+fine for a branch whose individual commits are worth keeping.
+
+## Release
+
+```bash
+git switch -c release/v0.7.0 public/dev
+# bump the version in Cargo.toml, update the changelog, no other change
+git push -u public release/v0.7.0
+gh pr create --base main --title "release: 0.7.0 — <the headline>"
+# merge once CI is green, then tag the MERGE COMMIT on main:
+git fetch public && git tag v0.7.0 public/main && git push public v0.7.0
+git switch dev && git merge --ff-only public/main && git push public dev   # dev absorbs the bump
+```
+
+Tag from `main` after the merge, never from the release branch. `release.yml` fires on `v*` and
+**only builds** — it does not run the test suite, so the tag must sit on a commit `ci.yml` already
+proved green. A tag placed outside `main` has never been tested by CI (this happened for 0.6.5).
+
+After publishing, check that the landing page and the install scripts point at the new version —
+they are a separate deploy and drift on their own.
+
+## Hotfix
+
+A production break that cannot wait for the next release:
+
+```bash
+git switch -c hotfix/v0.7.1 public/main
+# the smallest possible fix + its regression test
+gh pr create --base main
+```
+
+After it merges and is tagged, open a second PR merging `main` back into `dev`, or the fix is lost
+at the next release.
+
+## What protection enforces
+
+On both `main` and `dev`:
+
+- pull request required — no direct pushes, including for the maintainer
+- CI (`build + test` on ubuntu, macos and windows) must pass
+- CLA check must pass
+- code-owner approval required (see [CODEOWNERS](../.github/CODEOWNERS))
+- branch must be up to date with its base before merging
+- force-push and deletion blocked
+- conversations must be resolved before merge
+
+The `cla-signatures` branch stores the signature ledger and **must stay unprotected** — the CLA bot
+writes to it directly and cannot open a PR against a protected branch.
+
+## Local gates (not enforceable by GitHub)
+
+CI runs the same commands, but finding it locally is minutes instead of a red PR:
+
+```bash
+cargo fmt
+cargo clippy
+cargo test --bin aizen        # slow on Windows — run it in the background, not a 120 s shell call
+cargo build --release --bin aizen
+```
+
+The hard constraints a reviewer will reject a PR over are in [CLAUDE.md](../CLAUDE.md): pure Rust,
+one static binary, no C/native dependency, rustls only, and no casual regression of startup time or
+binary size.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -352,6 +352,7 @@ aizen agent --yes "fix the failing test in src/parse.rs"   # pre-approve file/sh
 aizen agent --max-iters 40 "..."                            # raise the step cap
 aizen agent --save-session "..."                            # keep the transcript for /sessions
 aizen agent --effort high "..."                             # this run only; the config is untouched
+aizen agent --image shot.png "why is this button misaligned?"  # vision: repeat --image for more
 ```
 Behavior worth knowing:
 - **Nothing is saved unless you ask.** This subcommand is also the scripting and CI entry point, so
@@ -367,6 +368,15 @@ Behavior worth knowing:
   typed REPL turn goes through, against the task text. Omit the flag and nothing changes: the
   configured `reasoning_effort` applies and the request is byte-identical to one from a core that
   never had the flag. The tier is named on **stderr**, next to the rest of the trace.
+- **Images are attached, not described.** `--image <PATH>` inlines a PNG/JPEG/GIF/WebP (≤ 8 MB) into
+  the first user message as an `image_url` data part — the same wire shape the REPL produces when you
+  drag a file onto the window or press Ctrl-O to grab a screenshot — so a front-end driving this
+  subcommand gets vision without driving the REPL. Repeat the flag for more than one image. The model
+  must be vision-capable; the files are read **before** the endpoint is resolved, and a path that is
+  not a readable image ends the run there rather than being skipped, because an attachment that
+  silently vanished would yield a confident answer about an image nothing ever sent. Note the
+  difference from the REPL: a typed line only lifts paths that really are images and leaves anything
+  else as prose, which is right for something a human typed — a flag is deliberate, so it is loud.
 - **How tools reach the model** — the session's tool registry is the single source of truth. Its
   definitions (name, description, JSON Schema) are sent through the provider's **native** tool field:
   OpenAI-compatible gateways and Anthropic get `tools[{type:"function",function:{…}}]`, the ChatGPT

--- a/src/agent/builtin.rs
+++ b/src/agent/builtin.rs
@@ -3141,6 +3141,11 @@ impl Tool for ShellRun {
     fn workspace_effect(&self, _args: &Value) -> WorkspaceEffect {
         WorkspaceEffect::OpaqueWorkspace
     }
+    fn command_to_guard(&self, args: &Value) -> Option<String> {
+        args.get("command")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    }
     fn execute(&self, args: &Value) -> Result<String> {
         let command = str_arg(args, "command")?;
         let dir = match args.get("cwd").and_then(|v| v.as_str()) {
@@ -3299,15 +3304,56 @@ impl Tool for ShellRun {
 /// filenames are not valid UTF-8 → `read_to_string` would silently drop the ENTIRE output and the
 /// agent would see a blank result. Lossy decoding keeps the ASCII structure (paths, sizes, the
 /// listing layout) and only the odd accented byte degrades to `�`.
+///
+/// BOUNDED IN RAM, not just in the transcript: the old `read_to_end` buffered the child's whole
+/// output before `truncate_result` ever saw it, so one `cat`ed multi-gigabyte file OOMed the CLI
+/// (the `process` tool ring-buffers at ingest; this path forgot to). Head + tail are kept —
+/// build/test logs put the verdict at the end — with a marker naming what fell out.
 pub(crate) fn drain<R: std::io::Read>(pipe: Option<R>) -> String {
-    match pipe {
-        Some(mut p) => {
-            let mut bytes = Vec::new();
-            let _ = p.read_to_end(&mut bytes);
-            String::from_utf8_lossy(&bytes).into_owned()
+    /// First bytes kept verbatim (the command header, the first error).
+    const HEAD: usize = 1 << 20; // 1 MB
+    /// Last bytes kept verbatim (the exit summary, the failing test names).
+    const TAIL: usize = 1 << 20; // 1 MB
+    let Some(mut p) = pipe else {
+        return String::new();
+    };
+    let mut head: Vec<u8> = Vec::new();
+    let mut tail: std::collections::VecDeque<u8> = std::collections::VecDeque::new();
+    let mut dropped: usize = 0;
+    let mut buf = [0u8; 8192];
+    loop {
+        match p.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                let mut chunk = &buf[..n];
+                if head.len() < HEAD {
+                    let take = (HEAD - head.len()).min(chunk.len());
+                    head.extend_from_slice(&chunk[..take]);
+                    chunk = &chunk[take..];
+                }
+                if !chunk.is_empty() {
+                    tail.extend(chunk.iter().copied());
+                    if tail.len() > TAIL {
+                        let excess = tail.len() - TAIL;
+                        tail.drain(..excess);
+                        dropped += excess;
+                    }
+                }
+            }
         }
-        None => String::new(),
     }
+    let mut out = String::from_utf8_lossy(&head).into_owned();
+    if dropped > 0 {
+        out.push_str(&format!(
+            "\n… [{dropped} bytes omitted — output exceeded the in-memory cap; first and last \
+             1 MB kept] …\n"
+        ));
+    }
+    if !tail.is_empty() {
+        let tail_bytes: Vec<u8> = tail.into();
+        out.push_str(&String::from_utf8_lossy(&tail_bytes));
+    }
+    out
 }
 
 // ── skill_load ───────────────────────────────────────────────────────────────
@@ -3652,7 +3698,9 @@ mod tests {
              description or gate a tool rather than raising the ceiling.\n{}",
             dump()
         );
-        if let Some((name, whole)) = rows.first() {
+        // EVERY row, not just the largest: three tools at 1,399 B each used to pass unnoticed
+        // while the ratchet only policed the single worst offender.
+        for (name, whole) in &rows {
             assert!(
                 *whole <= PER_TOOL_CEILING,
                 "tool `{name}` is {whole} B (per-tool ceiling {PER_TOOL_CEILING}) — its \
@@ -3719,12 +3767,14 @@ mod tests {
             "top-level tool schema {total} B exceeds {TOTAL_CEILING} B:\n{}",
             dump()
         );
-        assert!(
-            rows.first()
-                .is_none_or(|(_, bytes)| *bytes <= PER_TOOL_CEILING),
-            "one top-level tool exceeds {PER_TOOL_CEILING} B:\n{}",
-            dump()
-        );
+        // Every row (not just the largest) — same reason as the core ratchet above.
+        for (name, bytes) in &rows {
+            assert!(
+                *bytes <= PER_TOOL_CEILING,
+                "top-level tool `{name}` is {bytes} B (ceiling {PER_TOOL_CEILING}):\n{}",
+                dump()
+            );
+        }
     }
 
     #[test]

--- a/src/agent/builtin.rs
+++ b/src/agent/builtin.rs
@@ -1673,33 +1673,27 @@ impl FileRead {
         Self { root }
     }
 }
-impl Tool for FileRead {
-    fn name(&self) -> &str {
-        "file_read"
-    }
-    fn description(&self) -> &str {
-        "Read a file (optionally a 1-based line range). Use before editing. Set number:true to \
-         prefix each line with its 1-based number (`N|line`) for orientation — leave it off (the \
-         default) when you'll feed the text back into file_edit's old_string. A relative path \
-         resolves under the working directory; an absolute path or `../` reads elsewhere too. \
-         To learn a file's shape use lsp_document_symbols, and to read ONE named item use \
-         read_symbol — both are far cheaper than dumping the whole file here. Read-only."
-    }
-    fn parameters(&self) -> Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "path": {"type": "string"},
-                "start": {"type": "integer", "description": "1-based first line (optional)"},
-                "end": {"type": "integer", "description": "1-based last line (optional)"},
-                "number": {"type": "boolean", "description": "prefix each line with `N|` (default false)"}
-            },
-            "required": ["path"],
-            "additionalProperties": false
-        })
-    }
-    fn execute(&self, args: &Value) -> Result<String> {
-        let path = str_arg(args, "path")?;
+/// Cap on entries honoured in one `files:[…]` batch read. Enough to cover every hit of a search
+/// turn in one call; anything past it is reported (never silently dropped) so the model knows to
+/// call again.
+const MULTI_READ_MAX_FILES: usize = 8;
+
+impl FileRead {
+    /// One file (or slice of it) — the shared body behind both the single `path` form and each
+    /// `files:[…]` entry. `max_lines`/`max_bytes` bound a WHOLE-file read (a batch splits the
+    /// single-call budget across its entries); `symbol_hint` gates the LSP advisory, which only
+    /// the single form emits (once per batch would be spam).
+    #[allow(clippy::too_many_arguments)]
+    fn read_one(
+        &self,
+        path: &str,
+        start: Option<u64>,
+        end: Option<u64>,
+        number: bool,
+        max_lines: usize,
+        max_bytes: usize,
+        symbol_hint: bool,
+    ) -> Result<String> {
         let resolved = confine(&self.root, path, true)?;
         let content = std::fs::read_to_string(&resolved)
             .with_context(|| format!("reading {}", resolved.display()))?;
@@ -1711,25 +1705,21 @@ impl Tool for FileRead {
             &resolved,
             &crate::core::persist::FileFingerprint::for_bytes(content.as_bytes()),
         );
-        let start = args.get("start").and_then(|v| v.as_u64());
-        let end = args.get("end").and_then(|v| v.as_u64());
-        let number = args
-            .get("number")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
         // The whole file — verbatim under budget (the common case; keeps old_string round-trips
         // byte-exact), or a clearly-marked head+tail preview when it's pathologically large.
         if start.is_none() && end.is_none() && !number {
-            let view = budget_view(&content, path, FILE_READ_MAX_LINES, FILE_READ_MAX_BYTES);
+            let view = budget_view(&content, path, max_lines, max_bytes);
             // Retrieval-first nudge (mức 2): a long whole-file SOURCE read the model likely needs
             // one item from. Advisory — the full `view` still follows — and only when the symbol
             // tools it names are actually available (`is_code` + LSP on). Prepended so the model
             // sees it before committing to re-reading the same file next turn.
-            let is_code = crate::agent::lsp::discovery::server_for_path(&resolved).is_some();
-            let lsp_on = crate::agent::lsp::LSP.is_enabled();
-            let line_count = content.lines().count();
-            if let Some(hint) = whole_file_symbol_hint(is_code, lsp_on, line_count) {
-                return Ok(format!("{hint}\n{view}"));
+            if symbol_hint {
+                let is_code = crate::agent::lsp::discovery::server_for_path(&resolved).is_some();
+                let lsp_on = crate::agent::lsp::LSP.is_enabled();
+                let line_count = content.lines().count();
+                if let Some(hint) = whole_file_symbol_hint(is_code, lsp_on, line_count) {
+                    return Ok(format!("{hint}\n{view}"));
+                }
             }
             return Ok(view);
         }
@@ -1750,6 +1740,112 @@ impl Tool for FileRead {
         } else {
             Ok(lines[s - 1..e].join("\n"))
         }
+    }
+
+    /// The `files:[…]` batch form: N files/slices in ONE call — one round-trip instead of a
+    /// read-per-turn dribble. Per-entry errors are reported INLINE (a missing file must not void
+    /// the seven good reads next to it), and whole-file entries split the single-call budget so a
+    /// batch cannot admit N× the bytes one call may return.
+    fn read_many(&self, list: &[Value], args: &Value) -> Result<String> {
+        if list.is_empty() {
+            bail!("files[] is empty — pass at least one {{path,start,end}} entry, or use `path`");
+        }
+        let number = args
+            .get("number")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let shown = &list[..list.len().min(MULTI_READ_MAX_FILES)];
+        let per_lines = (FILE_READ_MAX_LINES / shown.len()).max(200);
+        let per_bytes = (FILE_READ_MAX_BYTES / shown.len()).max(20_000);
+        let mut out: Vec<String> = Vec::with_capacity(shown.len() + 1);
+        for entry in shown {
+            let Some(path) = entry.get("path").and_then(|v| v.as_str()) else {
+                out.push("── (entry missing `path`) ──".to_string());
+                continue;
+            };
+            let start = entry.get("start").and_then(|v| v.as_u64());
+            let end = entry.get("end").and_then(|v| v.as_u64());
+            let header = match (start, end) {
+                (None, None) => format!("── {path} ──"),
+                (s, e) => format!(
+                    "── {path}:{}-{} ──",
+                    s.map_or("1".to_string(), |v| v.to_string()),
+                    e.map_or("end".to_string(), |v| v.to_string()),
+                ),
+            };
+            match self.read_one(path, start, end, number, per_lines, per_bytes, false) {
+                Ok(body) => out.push(format!("{header}\n{body}")),
+                Err(err) => out.push(format!("{header}\nerror: {err:#}")),
+            }
+        }
+        if list.len() > MULTI_READ_MAX_FILES {
+            out.push(format!(
+                "…[{} more file(s) not read — {MULTI_READ_MAX_FILES} per call max; call again for the rest]",
+                list.len() - MULTI_READ_MAX_FILES
+            ));
+        }
+        Ok(out.join("\n"))
+    }
+}
+
+impl Tool for FileRead {
+    fn name(&self) -> &str {
+        "file_read"
+    }
+    fn description(&self) -> &str {
+        "Read a file (optionally a 1-based start/end line range), or SEVERAL files in ONE call via \
+         files:[{path,start,end},…] — batch independent reads instead of one per turn. Use before \
+         editing. Set number:true to prefix each line with its 1-based number (`N|line`) — leave it \
+         off (the default) when you'll feed the text back into file_edit's old_string. A relative \
+         path resolves under the working directory; absolute or `../` paths read elsewhere too. For \
+         ONE named item prefer lsp_document_symbols + read_symbol over dumping the file. Read-only."
+    }
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "start": {"type": "integer", "description": "1-based first line (optional)"},
+                "end": {"type": "integer", "description": "1-based last line (optional)"},
+                "number": {"type": "boolean", "description": "prefix each line with `N|` (default false)"},
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "start": {"type": "integer"},
+                            "end": {"type": "integer"}
+                        },
+                        "required": ["path"]
+                    },
+                    "description": "batch form: several files/slices in one call (max 8); overrides path"
+                }
+            },
+            "required": [],
+            "additionalProperties": false
+        })
+    }
+    fn execute(&self, args: &Value) -> Result<String> {
+        if let Some(list) = args.get("files").and_then(|v| v.as_array()) {
+            return self.read_many(list, args);
+        }
+        let path = str_arg(args, "path")?;
+        let start = args.get("start").and_then(|v| v.as_u64());
+        let end = args.get("end").and_then(|v| v.as_u64());
+        let number = args
+            .get("number")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        self.read_one(
+            path,
+            start,
+            end,
+            number,
+            FILE_READ_MAX_LINES,
+            FILE_READ_MAX_BYTES,
+            true,
+        )
     }
 }
 
@@ -3657,6 +3753,53 @@ mod tests {
         assert!(whole_file_symbol_hint(false, true, 800).is_none());
         assert!(whole_file_symbol_hint(true, false, 800).is_none());
         assert!(whole_file_symbol_hint(true, true, FILE_READ_MAX_LINES + 1).is_none());
+    }
+
+    #[test]
+    fn file_read_files_batch_reads_slices_and_reports_per_file_errors() {
+        let root = temp_root("multi-read");
+        std::fs::write(root.join("a.txt"), "alpha-1\nalpha-2\nalpha-3\n").unwrap();
+        std::fs::write(root.join("b.txt"), "beta-1\nbeta-2\nbeta-3\nbeta-4\n").unwrap();
+        let t = FileRead::new(root);
+        let out = t
+            .execute(&serde_json::json!({"files": [
+                {"path": "a.txt"},
+                {"path": "b.txt", "start": 2, "end": 3},
+                {"path": "missing.txt"}
+            ]}))
+            .unwrap();
+        // Whole file, a range slice, and an inline per-entry error — all in ONE result.
+        assert!(out.contains("── a.txt ──"), "whole-file header: {out}");
+        assert!(out.contains("alpha-3"), "whole-file body: {out}");
+        assert!(out.contains("── b.txt:2-3 ──"), "range header: {out}");
+        assert!(out.contains("beta-2\nbeta-3"), "range body: {out}");
+        assert!(!out.contains("beta-4"), "range must exclude line 4: {out}");
+        assert!(
+            out.contains("── missing.txt ──\nerror:"),
+            "a missing file reports inline instead of voiding the batch: {out}"
+        );
+    }
+
+    #[test]
+    fn file_read_files_batch_caps_entries_and_says_so() {
+        let root = temp_root("multi-read-cap");
+        for i in 0..10 {
+            std::fs::write(root.join(format!("f{i}.txt")), format!("body-{i}\n")).unwrap();
+        }
+        let files: Vec<serde_json::Value> = (0..10)
+            .map(|i| serde_json::json!({"path": format!("f{i}.txt")}))
+            .collect();
+        let t = FileRead::new(root);
+        let out = t.execute(&serde_json::json!({ "files": files })).unwrap();
+        assert!(out.contains("body-7"), "8th entry still read: {out}");
+        assert!(
+            !out.contains("body-8"),
+            "9th entry must be dropped, not read: {out}"
+        );
+        assert!(
+            out.contains("2 more file(s) not read"),
+            "the drop is REPORTED, never silent: {out}"
+        );
     }
 
     #[test]

--- a/src/agent/clarify.rs
+++ b/src/agent/clarify.rs
@@ -66,6 +66,32 @@ fn build(question: &str, options: &[String]) -> (String, String) {
     (display, ack)
 }
 
+/// Inverse of [`build`]'s display half: split a stored display back into the question and its
+/// numbered options, so the sticky REPL can raise a picker over the input box. Lives HERE, next to
+/// `build`, because the two must agree on the format — the round-trip test below pins them
+/// together. A display that doesn't match the shape `build` emits (a hand-written AwaitingInput
+/// string, a multi-line question) yields no options, which safely degrades to the free-text path.
+pub fn parse_display(display: &str) -> (&str, Vec<String>) {
+    let mut lines = display.lines();
+    let q = lines.next().unwrap_or("").trim();
+    let mut opts = Vec::new();
+    for l in lines {
+        let t = l.trim_start();
+        let numbered = t
+            .split_once(". ")
+            .filter(|(n, rest)| {
+                !n.is_empty() && n.chars().all(|c| c.is_ascii_digit()) && !rest.trim().is_empty()
+            })
+            .map(|(_, rest)| rest.trim().to_string());
+        match numbered {
+            Some(o) => opts.push(o),
+            // Any non-option line means this is NOT build()'s shape — don't guess.
+            None => return (q, Vec::new()),
+        }
+    }
+    (q, opts)
+}
+
 pub struct Clarify;
 
 impl Tool for Clarify {
@@ -150,6 +176,29 @@ mod tests {
             ack.contains("STOP now"),
             "the model must be told to wait, not re-ask: {ack}"
         );
+    }
+
+    #[test]
+    fn parse_display_roundtrips_build() {
+        let opts = vec!["src/a.rs".to_string(), "option 2. with dots".to_string()];
+        let (display, _) = build("Which file?", &opts);
+        let (q, parsed) = parse_display(&display);
+        assert_eq!(q, "Which file?");
+        assert_eq!(parsed, opts, "options must survive the round-trip verbatim");
+        // No options → none parsed.
+        let (display, _) = build("Proceed?", &[]);
+        assert_eq!(parse_display(&display), ("Proceed?", Vec::new()));
+    }
+
+    #[test]
+    fn parse_display_refuses_foreign_shapes() {
+        // A multi-line question that never came from build() must not be misread as options.
+        let (q, opts) = parse_display("What now?\nsome free-form second line");
+        assert_eq!(q, "What now?");
+        assert!(opts.is_empty(), "non-numbered line → no menu: {opts:?}");
+        // A numbered line followed by a stray line → also refuse (all-or-nothing).
+        let (_, opts) = parse_display("Q?\n  1. yes\ntrailing prose");
+        assert!(opts.is_empty());
     }
 
     #[test]

--- a/src/agent/mcp.rs
+++ b/src/agent/mcp.rs
@@ -581,9 +581,22 @@ struct StdioTransport {
     stderr: Arc<std::sync::Mutex<String>>,
     /// Literal secret values (env/header/token) to strip from the stderr tail before it's surfaced.
     secrets: Vec<String>,
+    /// Whole-TREE containment (Windows Job Object / Unix process group). `kill_on_drop` on
+    /// `_child` reaps only the direct child — the `cmd /C` shim on Windows — so without this the
+    /// real server process it launched outlived the transport, holding pipes open. Terminated in
+    /// `Drop` below.
+    containment: crate::core::proctree::Containment,
     /// Sandbox bookkeeping (audit already written as `spawned`); holds the server's private temp
     /// directory alive for the connection's lifetime.
     _sandbox: crate::sandbox::runner::SpawnGuard,
+}
+
+impl Drop for StdioTransport {
+    fn drop(&mut self) {
+        // Kill the whole tree, not just the shim. Runs before the fields drop, so `kill_on_drop`
+        // on `_child` afterwards is a harmless second shot at an already-dead process.
+        crate::core::proctree::terminate_tree(&self.containment);
+    }
 }
 
 impl StdioTransport {
@@ -1469,6 +1482,12 @@ async fn connect_stdio(cfg: &ServerConfig) -> Result<Transport> {
             return Err(e).with_context(|| format!("spawning MCP server `{command}`"));
         }
     };
+    // TREE containment, same as every other runner-prepared spawn. `kill_on_drop` alone reaps
+    // only the direct child — which on Windows is the `cmd /C` shim, so dropping the transport
+    // orphaned the real `node.exe`/`python.exe` holding the pipes: exactly the orphan class
+    // `proctree` exists to eliminate. This also arms the sandbox policy's Windows JobLimits,
+    // which ride on containment and were never applied to MCP children before.
+    let containment = sbx.contain_tokio(&child);
     let mut server_guard = sbx.into_guard();
     server_guard.finish(crate::sandbox::runner::Outcome::Spawned);
     let stdin = child.stdin.take().context("child stdin unavailable")?;
@@ -1503,6 +1522,7 @@ async fn connect_stdio(cfg: &ServerConfig) -> Result<Transport> {
         stderr: stderr_buf,
         // Env values commonly carry the child's API key/token — mask them out of the stderr tail.
         secrets: server_secrets(cfg, None),
+        containment,
         _sandbox: server_guard,
     }))
 }

--- a/src/agent/mcp_serve.rs
+++ b/src/agent/mcp_serve.rs
@@ -1,0 +1,466 @@
+//! `aizen mcp serve` — aizen as an MCP **server**, so another agent can hand it work.
+//!
+//! Everything else in this crate points outwards: [`crate::agent::mcp`] connects to servers and
+//! borrows their tools. This is the same protocol pointed the other way. Claude Code, Codex, Cursor
+//! — anything that speaks MCP — spawns `aizen mcp serve` in a repository and gets three tools:
+//! dispatch one specialist, fan several out and synthesise them, and ask who is available.
+//!
+//! Why it is worth having, in one line: **aizen's specialists become callable by an agent that is
+//! not aizen.** A card you wrote once in `~/.aizen/agents` — your reviewer, with your rules, on your
+//! model — can now be dispatched by whatever assistant you happen to be talking to, without that
+//! assistant knowing anything about aizen beyond the tool schema.
+//!
+//! Three things follow from the implementation being this thin:
+//!
+//! * The tools are *core's own* `task` and `workflow`, taken out of the same registry a REPL turn
+//!   builds. Schema, description, scoping, depth cap, concurrency gate, checkpointing and the
+//!   orchestration registry all come along unchanged, because none of it is reimplemented here.
+//! * Every dispatch therefore writes a run manifest to `~/.aizen/orchestration/runs`, so a fan-out
+//!   started by Claude Code shows up in `/workflows` and in the desktop's office pane exactly like
+//!   one started by aizen itself — stamped with who asked, from the MCP handshake.
+//! * **Write access is a decision made on the command line, never in the tool call.** Started plain,
+//!   the server refuses any dispatch that resolves to a registry holding a destructive tool; the
+//!   caller can ask for a `coder`, and be told no. `--yes` is what lifts that, and it is typed by a
+//!   person into their own shell. An agent cannot grant itself the right to edit this repository by
+//!   choosing a different argument — nor by choosing a different tool NAME: `tools/call` accepts
+//!   only the advertised names ([`ADVERTISED`] + [`ROSTER`]), so the rest of the registry this
+//!   process holds (`shell_run`, `file_write`, …) is unreachable from the wire. Both axes together
+//!   are the security posture of this file.
+//!
+//! Deliberately absent: this process arms no LSP session and prints nothing to stdout that is not
+//! protocol. A language server spawned for a client that only wanted a code review is a cost nobody
+//! asked for, and one stray `println!` in the middle of a JSON-RPC stream is a corrupted transport
+//! rather than a cosmetic bug — so diagnostics go to stderr and stay there.
+
+use std::io::{BufRead, Write};
+
+use anyhow::Result;
+use serde_json::{json, Value};
+
+use crate::agent::tools::ToolRegistry;
+
+/// The revision of MCP this speaks. Matched to what core's own client negotiates.
+const PROTOCOL: &str = "2025-06-18";
+
+/// The three tools offered. `task` and `workflow` are proxies onto the real registry entries; only
+/// `agents` is written here, because "who could I ask?" is a question core answers to a person on a
+/// terminal and had no wire form.
+const ROSTER: &str = "agents";
+
+/// The registry names a wire client may reach. `tools/list` advertises these and `tools/call`
+/// refuses everything else BY NAME, before the registry is consulted. The registry behind this
+/// server is the full top-level surface (it has to be — `task` resolves its sub-registries out of
+/// it), so it also holds `shell_run` and `file_write` at Yolo approval with the loop-level
+/// cmd_guard floor nowhere on this path. This list, not the registry, is the boundary.
+const ADVERTISED: [&str; 2] = ["task", "workflow"];
+
+/// One dispatch's answer, bounded. A sub-agent that returns a whole file tree is a sub-agent that
+/// was asked the wrong question, and the caller's context window is not ours to spend.
+const MAX_RESULT: usize = 60_000;
+
+pub fn run(allow_write: bool) -> Result<()> {
+    // Nobody is watching this process: the "user" is another agent on a JSON-RPC pipe, and the
+    // one-time sandbox degradation warning goes to a stderr nobody reads. Marked unattended so the
+    // sandbox applies the same fail-closed rule it applies to cron and the serve daemon.
+    crate::sandbox::set_process_unattended();
+
+    // Resolved once, exactly as the one-shot CLI path resolves it: flags are absent here, so this is
+    // env then `~/.aizen/cli-config.json`. A server with no key should fail now, loudly, on the
+    // terminal of the person who started it — not on the first tool call, inside another agent's
+    // turn, where the error becomes a sentence in a transcript nobody reads.
+    let (base_url, api_key, model) = crate::core::endpoint::resolve_endpoint(None, None, None)?;
+    let client = crate::core::endpoint::http_client()?;
+    let context_window = crate::ui::context_report::resolve_ctx_window(&model).0;
+
+    /* Approval is `Yolo` in both modes, and that is not the hole it looks like.
+    There is no human on this end of the pipe, so `Ask` would be a prompt written to a stream
+    that carries JSON-RPC — it would corrupt the transport and then block forever waiting for an
+    answer that cannot arrive. The real gate is one layer up: without `--yes` a dispatch that
+    could write is refused before it starts, so everything that reaches the loop is read-only and
+    has nothing to approve. With `--yes` the person starting the server has said the quiet part
+    out loud on their own command line. */
+    let registry = crate::agent::builtin::default_registry_with_task(
+        client,
+        base_url,
+        api_key,
+        model,
+        crate::core::approval::ApprovalMode::Yolo,
+        context_window,
+        None, // cwd IS the project: the client spawned us inside the repository it means
+    )?;
+
+    let stdin = std::io::stdin();
+    let mut out = std::io::stdout();
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            // The client closed the pipe mid-line. Nothing to answer and nobody to answer to.
+            Err(_) => break,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Some(reply) = respond(&registry, allow_write, &line) else {
+            continue;
+        };
+        writeln!(out, "{reply}")?;
+        out.flush()?;
+    }
+    Ok(())
+}
+
+/// One line in, at most one line out. `None` means "say nothing" — which is the correct and
+/// required answer to a notification, and to anything unparseable enough that we cannot tell whose
+/// reply it would be.
+fn respond(registry: &ToolRegistry, allow_write: bool, line: &str) -> Option<String> {
+    let msg: Value = serde_json::from_str(line).ok()?;
+    let id = msg.get("id").cloned();
+    let method = msg.get("method").and_then(Value::as_str).unwrap_or("");
+    let params = msg.get("params").cloned().unwrap_or_else(|| json!({}));
+
+    let outcome = dispatch(registry, allow_write, method, &params);
+
+    // A JSON-RPC notification carries no id and must never be answered. Some clients treat a reply
+    // to one as a protocol violation and drop the connection, so this check comes before the work
+    // is turned into a message — not after.
+    let id = id?;
+    let body = match outcome {
+        Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
+        Err(message) => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {"code": -32601, "message": message},
+        }),
+    };
+    serde_json::to_string(&body).ok()
+}
+
+fn dispatch(
+    registry: &ToolRegistry,
+    allow_write: bool,
+    method: &str,
+    params: &Value,
+) -> Result<Value, String> {
+    match method {
+        "initialize" => Ok(initialize(params)),
+        "ping" => Ok(json!({})),
+        "tools/list" => Ok(json!({ "tools": tools(registry, allow_write) })),
+        "tools/call" => Ok(call(registry, allow_write, params)),
+        other => Err(format!("phương thức không hỗ trợ: {other}")),
+    }
+}
+
+/* The handshake, and the one piece of information this file goes out of its way to keep.
+`clientInfo.name` is the caller naming itself, and it is stamped onto every run this process
+starts. That is why the office pane can seat "Claude Code" at the director's desk without any
+guesswork: nothing is inferred from a process tree or a directory name — the program said who it
+was, in the first message it sent. It is a self-reported label and is treated as one: bounded,
+stripped of control characters, and used for display only. */
+fn initialize(params: &Value) -> Value {
+    let who = params
+        .get("clientInfo")
+        .and_then(|c| c.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    crate::agent::orchestration::set_origin(who);
+    json!({
+        "protocolVersion": PROTOCOL,
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": "aizen", "version": env!("CARGO_PKG_VERSION")},
+    })
+}
+
+fn tools(registry: &ToolRegistry, allow_write: bool) -> Vec<Value> {
+    let mut out = Vec::new();
+    // Descriptions and schemas are read off the live registry rather than restated here. Restating
+    // them would mean this file and the tool could disagree about what the tool does, and the
+    // caller would believe this file.
+    for name in ADVERTISED {
+        let Some(tool) = registry.get(name) else {
+            continue;
+        };
+        let mut description = tool.description().to_string();
+        if !allow_write {
+            description.push_str(
+                "\n\nREAD-ONLY SERVER: this aizen was started without --yes, so any dispatch that \
+                 resolves to a sub-agent holding edit or shell tools (role coder/tester, or a \
+                 specialist whose card grants them) is refused before it runs. Use planner, \
+                 reviewer, or a read-only specialist.",
+            );
+        }
+        out.push(json!({
+            "name": name,
+            "description": description,
+            "inputSchema": tool.parameters(),
+        }));
+    }
+    out.push(json!({
+        "name": ROSTER,
+        "description":
+            "List the aizen specialists available on this machine: slug to pass as `agent`, what \
+             each is for, and whether it can write. Call this before `task` when you want a named \
+             specialist rather than a generic role.",
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": false},
+    }));
+    out
+}
+
+fn call(registry: &ToolRegistry, allow_write: bool, params: &Value) -> Value {
+    let name = params.get("name").and_then(Value::as_str).unwrap_or("");
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    if name == ROSTER {
+        return text(roster(), false);
+    }
+    // The allowlist comes BEFORE the registry lookup — see [`ADVERTISED`]. Every other registry
+    // name must be unreachable from the wire, whether or not it exists.
+    if !ADVERTISED.contains(&name) {
+        return text(
+            format!("không có công cụ tên '{name}' — máy chủ này chỉ có: task, workflow, {ROSTER}"),
+            true,
+        );
+    }
+    let Some(tool) = registry.get(name) else {
+        return text(format!("không có công cụ tên '{name}'"), true);
+    };
+    if !allow_write {
+        if let Some(refusal) = refuse_write(registry, name, &args) {
+            return text(refusal, true);
+        }
+    }
+    // A panicking tool must cost one answer, not the transport: unwinding out of `run()` kills
+    // every future call the client was going to make, mid-session, with no protocol goodbye.
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| tool.execute(&args))) {
+        Ok(Ok(answer)) => text(bounded(answer), false),
+        Ok(Err(e)) => text(format!("{e}"), true),
+        Err(_) => text(
+            "lỗi: công cụ panic khi chạy — chi tiết ở stderr của server",
+            true,
+        ),
+    }
+}
+
+/// Cap an answer at [`MAX_RESULT`] without ever cutting inside a UTF-8 sequence.
+/// `String::truncate` takes a BYTE index and panics off a char boundary — and these answers carry
+/// Vietnamese prose, so a multibyte character at the cap is the common case, not the corner.
+fn bounded(mut answer: String) -> String {
+    if answer.len() > MAX_RESULT {
+        let mut cut = MAX_RESULT;
+        while cut > 0 && !answer.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        answer.truncate(cut);
+        answer.push_str("\n… (cắt bớt)");
+    }
+    answer
+}
+
+/* The write gate.
+Whether a dispatch can write is not decided here — it is asked of the `task` tool, which answers
+by resolving the dispatch exactly as it would to run it and reporting whether the resulting
+registry holds a destructive tool. That indirection is the point: the rule lives in one place, so
+a specialist card that gains `shell_run` tomorrow is refused tomorrow without this file learning
+anything. A workflow is checked task by task, because one writer among twenty readers is still a
+writer. Verify mode has no roles at all — its children are refuters — so it has nothing to check. */
+fn refuse_write(registry: &ToolRegistry, name: &str, args: &Value) -> Option<String> {
+    let task = registry.get("task")?;
+    let refusal = |what: &str| {
+        Some(format!(
+            "từ chối: {what} sẽ chạy với quyền sửa tệp hoặc chạy lệnh, mà máy chủ này khởi động \
+             không có --yes.\nDùng role `planner` / `reviewer`, hoặc một specialist chỉ đọc — gọi \
+             `{ROSTER}` để xem ai chỉ đọc.\nMuốn cho ghi thật thì người dùng phải tự chạy lại: \
+             `aizen mcp serve --yes`. Quyền đó không nằm trong tham số bạn gửi.",
+        ))
+    };
+    match name {
+        "task" => (!task.is_concurrency_safe_for(args)).then(|| refusal("lượt này"))?,
+        "workflow" => args
+            .get("tasks")
+            .and_then(Value::as_array)
+            .and_then(|list| {
+                list.iter()
+                    .position(|t| {
+                        // Judge the shape that will actually run: a task with no `role` runs as
+                        // `reviewer` (workflow_tool's default), while the task tool's own oracle
+                        // defaults to `coder` — asking it about the bare value would refuse a
+                        // dispatch that was read-only all along.
+                        let mut t = t.clone();
+                        if let Some(o) = t.as_object_mut() {
+                            o.entry("role").or_insert_with(|| json!("reviewer"));
+                        }
+                        !task.is_concurrency_safe_for(&t)
+                    })
+                    .map(|i| refusal(&format!("việc thứ {} trong workflow", i + 1)))
+            })?,
+        _ => None,
+    }
+}
+
+/// Who is on the payroll, as a plain table. Read-only status comes from the same resolver the write
+/// gate consults, so the column cannot lie about what this server would actually allow.
+fn roster() -> String {
+    let root = std::env::current_dir().unwrap_or_default();
+    let enabled = crate::agents::enabled_set();
+    let mut lines = Vec::new();
+    for def in crate::agents::list() {
+        let slug = def.slug();
+        // No enabled-file at all means nobody has ever pinned anything, and everything is live.
+        let pinned = enabled.as_ref().is_none_or(|set| set.contains(&slug));
+        let reg = crate::agent::builtin::agent_registry(&def, &root);
+        let reach = if crate::agent::task_tool::dispatch_is_read_only(&reg) {
+            "chỉ đọc"
+        } else {
+            "ghi được tệp"
+        };
+        lines.push(format!(
+            "{slug}\t{reach}\t{}\t{}",
+            if pinned { "đang bật" } else { "đang tắt" },
+            def.description.trim(),
+        ));
+    }
+    if lines.is_empty() {
+        return "Chưa có specialist nào trên máy này. Dùng role planner/reviewer/coder/tester, \
+                hoặc tạo thẻ bằng `aizen agents install`."
+            .to_string();
+    }
+    format!(
+        "slug\tquyền\ttrạng thái\tmô tả\n{}\n\nTruyền slug vào tham số `agent` của `task`.",
+        lines.join("\n")
+    )
+}
+
+/// The MCP shape for a tool answer. A failed call is `isError` with the reason as text, not a
+/// JSON-RPC error: the caller is a model, and a model can read a sentence and try something else.
+fn text(body: impl Into<String>, failed: bool) -> Value {
+    json!({
+        "content": [{"type": "text", "text": body.into()}],
+        "isError": failed,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_notification_is_never_answered() {
+        let reg = ToolRegistry::new();
+        let note = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+        assert!(respond(&reg, false, note).is_none());
+    }
+
+    #[test]
+    fn garbage_gets_silence_rather_than_a_guess() {
+        let reg = ToolRegistry::new();
+        assert!(respond(&reg, false, "not json at all").is_none());
+    }
+
+    #[test]
+    fn the_handshake_names_the_caller() {
+        let reg = ToolRegistry::new();
+        let hello = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":
+            {"clientInfo":{"name":"Claude Code","version":"9"}}}"#;
+        let out = respond(&reg, false, hello).expect("initialize is answered");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["result"]["serverInfo"]["name"], "aizen");
+        assert_eq!(v["result"]["protocolVersion"], PROTOCOL);
+        assert_eq!(v["id"], 1);
+    }
+
+    #[test]
+    fn an_unknown_method_is_an_error_with_the_same_id() {
+        let reg = ToolRegistry::new();
+        let msg = r#"{"jsonrpc":"2.0","id":"abc","method":"resources/list"}"#;
+        let v: Value = serde_json::from_str(&respond(&reg, false, msg).unwrap()).unwrap();
+        assert_eq!(v["id"], "abc");
+        assert!(v["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("resources/list"));
+    }
+
+    #[test]
+    fn the_roster_tool_is_offered_even_with_no_dispatch_registry() {
+        let reg = ToolRegistry::new();
+        let listed = tools(&reg, false);
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0]["name"], ROSTER);
+    }
+
+    #[test]
+    fn a_read_only_server_says_so_in_every_dispatch_description() {
+        // Without a configured endpoint there is no task tool to read, so this asserts the shape of
+        // the amendment rather than its presence: whatever is advertised, the caller is told the
+        // rule it will be judged by before it writes a call.
+        let reg = ToolRegistry::new();
+        for t in tools(&reg, false) {
+            let d = t["description"].as_str().unwrap();
+            assert!(!d.is_empty(), "every advertised tool describes itself");
+        }
+    }
+
+    #[test]
+    fn a_missing_tool_answers_in_band() {
+        let reg = ToolRegistry::new();
+        let out = call(&reg, true, &json!({"name": "task", "arguments": {}}));
+        assert_eq!(out["isError"], true);
+        assert!(out["content"][0]["text"].as_str().unwrap().contains("task"));
+    }
+
+    #[test]
+    fn an_unadvertised_registry_tool_is_unreachable_by_name() {
+        // The registry behind a real server holds shell_run/file_write at Yolo approval; the wire
+        // must not be able to reach them by naming them, `--yes` or not. Asserted on the refusal
+        // text so a future "helpful" fallback to registry lookup fails this test loudly.
+        let reg = ToolRegistry::new();
+        for name in ["shell_run", "file_write", "file_edit", "memory_save"] {
+            for allow_write in [false, true] {
+                let out = call(&reg, allow_write, &json!({"name": name, "arguments": {}}));
+                assert_eq!(out["isError"], true, "{name} must be refused");
+                assert!(
+                    out["content"][0]["text"]
+                        .as_str()
+                        .unwrap()
+                        .contains("chỉ có: task, workflow"),
+                    "{name} must be refused by the allowlist, not by registry absence"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_answer_cap_never_cuts_inside_a_character() {
+        // A wall of 3-byte characters guarantees MAX_RESULT lands mid-sequence; the old
+        // `String::truncate(MAX_RESULT)` panicked here and took the whole server with it.
+        let wall = "ế".repeat(MAX_RESULT); // 3 bytes each — far over the cap
+        let out = bounded(wall);
+        assert!(out.len() <= MAX_RESULT + "\n… (cắt bớt)".len());
+        assert!(out.ends_with("(cắt bớt)"));
+        // Round-trip through str validation: a mid-char cut would have panicked already, but be
+        // explicit that what remains is valid UTF-8 of whole characters.
+        assert!(out.chars().all(|c| c == 'ế' || "\n… (cắt bớt)".contains(c)));
+    }
+
+    #[test]
+    fn the_write_gate_needs_a_task_tool_to_consult() {
+        // No registry, no oracle — and the gate refuses to invent an answer. `call` still refuses
+        // the dispatch, because the tool it would run is not there either.
+        let reg = ToolRegistry::new();
+        assert!(refuse_write(&reg, "task", &json!({"role": "coder"})).is_none());
+    }
+
+    #[test]
+    fn a_refusal_names_the_flag_that_lifts_it_and_not_an_argument() {
+        // The wording is load-bearing: a caller that reads "pass allow_write: true" would try it.
+        let reg = ToolRegistry::new();
+        let listed = tools(&reg, false);
+        let roster_desc = listed[0]["description"].as_str().unwrap();
+        assert!(
+            !roster_desc.contains("--yes"),
+            "the roster tool is not the gate"
+        );
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -978,6 +978,16 @@ where
     let mut hill_climb_reframed = false;
     let mut last_hill_climb_reminder = 0usize;
     let mut iter = 0usize;
+    // Identical-re-read short-circuit: sig(file_read args) → what that call answered last time.
+    // Cleared whenever history is rebuilt (compaction / emergency shrink) — the msg_index leg of
+    // the proof dies with the rebuild. Eviction blanks bodies IN PLACE, which the byte-level
+    // intact-check catches per entry, so no clear is needed there.
+    let mut read_cache: std::collections::HashMap<String, ReadCacheEntry> =
+        std::collections::HashMap::new();
+    // Batch-coach streak (see NUDGE_BATCH): consecutive turns whose ONLY call was one read-only
+    // retrieval. One-shot latch per run.
+    let mut single_read_streak = 0usize;
+    let mut batch_nudged = false;
     // GOAL MODE bypasses the iteration cap entirely: `/goal` promises to run until the goal is
     // genuinely finished, so the only exits are Esc (→ Cancelled, via `cancel::race`) or a verified
     // completion (→ Done, via the goal gate + verify gate). Ordinary turns keep `iter < cap`.
@@ -1223,6 +1233,7 @@ where
                             budget_band_shown = None; // …and the running budget signal (P-ctx1)
                             real_anchor = None; // spliced history invalidates the anchor
                             stall.forget_successes(); // summarized-away results must not mark a re-read as stale
+                            read_cache.clear(); // rebuilt indices — the short-circuit proof is void
                             est_now = estimate_tokens(messages) + schema_overhead;
                             if !cfg.quiet {
                                 let line =
@@ -1705,6 +1716,19 @@ where
         // CLASSIFY: the structured tool_calls array is the source of truth (a gateway may
         // emit finish_reason="stop"/"end_turn" alongside tool calls — ignore it here).
         if turn.tool_calls.is_empty() {
+            // MERGED DONE-GATE CASCADE: each gate below APPENDS its demand to `demands` instead of
+            // looping back immediately. One combined round-trip then carries every demand that
+            // fired — the old shape burned one full LLM iteration PER gate (verify → self-review →
+            // todo-poke → confidence could cost 4 sequential round-trips for one "done" claim; the
+            // model can fix all four in one pass). Per-gate budgets/latches are consumed exactly as
+            // before, so the total-work bound is unchanged — only the round-trip count shrinks.
+            // The goal and steering gates stay EXCLUSIVE (evaluated only when nothing else fired):
+            // the goal gate's `take_pending` drain must only happen at a real Done decision, and a
+            // steer left in the mailbox is picked up by the top-of-loop drain for free anyway.
+            let mut demands: Vec<String> = Vec::new();
+            // Set when THIS round's verify ran and failed — self-review must not spend its
+            // once-per-run oracle call reviewing code that is known-broken.
+            let mut verify_failed_now = false;
             // VERIFY/REPAIR GATE (F2 + W8): after an editing run, run a fast typecheck before Done.
             // On failure, record the premature "done", inject the errors, and loop back for a fix.
             // The gate RE-FIRES on EVERY "done" claim until it PASSES or the attempt budget
@@ -1772,6 +1796,7 @@ where
                     };
                     if !gate_passed {
                         verify_attempts += 1;
+                        verify_failed_now = true;
                         // GOAL MODE: a failed verify invalidates any completion claim the model made
                         // this turn — clear it so the stale claim can't leak through the goal gate to
                         // Done after the model fixes the errors. The `goal_complete` ack already tells
@@ -1781,17 +1806,6 @@ where
                         if cfg.goal.is_some() {
                             goal::clear();
                         }
-                        // Record the premature "done" before the user gate-failure message.
-                        // Normalize content to "" (never null): an assistant turn with neither
-                        // content nor tool_calls is malformed (400) on strict gateways.
-                        messages.push(Message {
-                            role: "assistant".to_string(),
-                            content: Some(turn.content.clone().unwrap_or_default()),
-                            tool_calls: Vec::new(),
-                            tool_call_id: None,
-                            images: Vec::new(),
-                            cache_control: None,
-                        });
                         // Once a phase has spent past half its repair budget, offer the rewind as an
                         // explicit escape hatch: patching further is often more costly than dropping
                         // back to the last clean phase mark and re-approaching. Reuses the existing
@@ -1804,34 +1818,38 @@ where
                                 failure_msg.push_str(&hint);
                             }
                         }
-                        messages.push(Message::user(failure_msg));
-                        iter += 1;
-                        continue;
-                    }
-                    // PASSED: latch it so a subsequent no-edit "done" doesn't needlessly re-run the
-                    // gate (a fresh successful edit clears the latch → new work is re-verified).
-                    verify_passed = true;
-                    // A clean verify is the OTHER phase boundary (decision: todo-close AND
-                    // verify-pass both mark phases). This catches the no-todo run — the model edited
-                    // and finished without ever flipping a todo, so `phase_boundary_crossed` never
-                    // fired. Stamp the still-uncheckpointed edits ONCE here as a verified phase.
-                    // Gated on `made_edits_in_phase` so a no-edit "done" (latch already clean) stamps
-                    // nothing; `save` dedups a zero-diff tree so it's free when the last todo boundary
-                    // already captured this exact tree.
-                    if cfg.checkpoint_each_edit && made_edits_in_phase {
-                        phase_counter += 1;
-                        stamp_phase_checkpoint(
-                            cfg.quiet,
-                            &format!("phase {phase_counter} verified"),
-                        );
-                        made_edits_in_phase = false;
-                        phase_todos_before = crate::agent::todo::snapshot();
+                        demands.push(failure_msg);
+                    } else {
+                        // PASSED: latch it so a subsequent no-edit "done" doesn't needlessly re-run
+                        // the gate (a fresh successful edit clears the latch → new work is
+                        // re-verified).
+                        verify_passed = true;
+                        // A clean verify is the OTHER phase boundary (decision: todo-close AND
+                        // verify-pass both mark phases). This catches the no-todo run — the model
+                        // edited and finished without ever flipping a todo, so
+                        // `phase_boundary_crossed` never fired. Stamp the still-uncheckpointed edits
+                        // ONCE here as a verified phase. Gated on `made_edits_in_phase` so a no-edit
+                        // "done" (latch already clean) stamps nothing; `save` dedups a zero-diff
+                        // tree so it's free when the last todo boundary already captured this tree.
+                        if cfg.checkpoint_each_edit && made_edits_in_phase {
+                            phase_counter += 1;
+                            stamp_phase_checkpoint(
+                                cfg.quiet,
+                                &format!("phase {phase_counter} verified"),
+                            );
+                            made_edits_in_phase = false;
+                            phase_todos_before = crate::agent::todo::snapshot();
+                        }
                     }
                 }
             }
+            // Exhausted budget with no pass → end the run honestly. `!verify_failed_now` keeps the
+            // round that SPENT the last attempt on its repair turn (the old `continue` did this by
+            // construction): only the NEXT tool-free claim, with nothing left to spend, returns.
             if cfg.enable_verify_gate
                 && made_any_edits
                 && !verify_passed
+                && !verify_failed_now
                 && verify_attempts >= cfg.max_verify_attempts
             {
                 if let Some(t) = &turn.content {
@@ -1850,7 +1868,9 @@ where
             // mode (roles.oracle configured → closure supplied) has a stronger model review the
             // `git diff` — its findings come back as a fix-or-rebut turn; an LGTM costs nothing
             // extra. Nudge mode makes THIS model re-read its own diff.
-            if cfg.enable_self_review && made_any_edits && !self_review_done {
+            // Skipped (latch UNSPENT) when this round's verify failed: the once-per-run oracle call
+            // must review code that typechecks, not the broken tree the verify demand is about.
+            if cfg.enable_self_review && made_any_edits && !self_review_done && !verify_failed_now {
                 self_review_done = true;
                 match &oracle {
                     // ORACLE MODE: the verify step gates Done. A review with a [BLOCKING] finding
@@ -1860,44 +1880,23 @@ where
                     Some(o) => {
                         if let Some(review) = oracle_review(o, &review_request).await {
                             if review.blocking {
-                                // Record the premature "done" so the review turn reads coherently,
-                                // then hand back a fix-or-rebut turn (the verify step gates Done).
-                                if let Some(t) = &turn.content {
-                                    if !t.trim().is_empty() {
-                                        messages.push(Message::assistant(t.clone()));
-                                    }
-                                }
-                                messages.push(Message::user(format!(
+                                demands.push(format!(
                                     "[self-review]\n{}\n\nFix each [BLOCKING] item above, or state briefly why it does not apply — then give your final answer. [ADVISORY] items are optional.",
                                     review.findings
-                                )));
-                                iter += 1;
-                                continue;
-                            }
-                            // Advisory-only: surface the notes ONCE as a trace (they don't gate
-                            // Done — the model isn't forced to churn on style), then finish this
-                            // turn. Falls through to the shared Done return below, which records the
-                            // final assistant text exactly once (no duplicate).
-                            if !cfg.quiet {
+                                ));
+                            } else if !cfg.quiet {
+                                // Advisory-only: surface the notes ONCE as a trace (they don't gate
+                                // Done — the model isn't forced to churn on style).
                                 emit_trace(&format!(
                                     "  └ self-review: advisory only (no blocking issue)\n{}",
                                     review.findings
                                 ));
                             }
                         }
-                        // else: LGTM / no diff → fall through to Done, no extra turn.
+                        // else: LGTM / no diff → no demand, no extra turn.
                     }
-                    // NUDGE MODE (no oracle): the model re-reads its own diff. One turn, always.
-                    None => {
-                        if let Some(t) = &turn.content {
-                            if !t.trim().is_empty() {
-                                messages.push(Message::assistant(t.clone()));
-                            }
-                        }
-                        messages.push(Message::user(SELF_REVIEW_NUDGE.to_string()));
-                        iter += 1;
-                        continue;
-                    }
+                    // NUDGE MODE (no oracle): the model re-reads its own diff. One demand, always.
+                    None => demands.push(SELF_REVIEW_NUDGE.to_string()),
                 }
             }
 
@@ -1921,28 +1920,18 @@ where
                             eprintln!("{line}");
                         }
                     }
-                    messages.push(Message {
-                        role: "assistant".to_string(),
-                        content: Some(turn.content.clone().unwrap_or_default()),
-                        tool_calls: Vec::new(),
-                        tool_call_id: None,
-                        images: Vec::new(),
-                        cache_control: None,
-                    });
-                    messages.push(Message::user(format!(
+                    demands.push(format!(
                         "{TODO_POKE_PREFIX} Session todos are still incomplete — you may not finish yet.\n\n\
                          Incomplete:\n{summary}\n\n\
                          Either (a) finish the remaining items and verify, or (b) mark items done only \
                          if genuinely complete, or (c) clear the todo list to abandon the plan — then stop.\n\
                          Attempt {todo_poke_attempts}/{}.",
                         cfg.max_todo_poke_attempts
-                    )));
-                    iter += 1;
-                    continue;
+                    ));
                 }
             }
 
-            // P0.2 CONFIDENCE GATE: Done + large confidence jump → one-shot re-check turn.
+            // P0.2 CONFIDENCE GATE: Done + large confidence jump → one-shot re-check demand.
             if cfg.enable_confidence_gate && confidence_gate_armed && !confidence_gate_cleared {
                 confidence_gate_cleared = true;
                 if !cfg.quiet {
@@ -1953,6 +1942,21 @@ where
                         eprintln!("{line}");
                     }
                 }
+                demands.push(format!(
+                    "{CONFIDENCE_GATE_PREFIX} You marked todo(s) done with a large confidence jump \
+                     without stepwise evidence.\n\n\
+                     Before finishing: re-run the relevant check (tests / verify / metric). \
+                     If checks pass, keep Done. If not, reopen the todo and fix.\n\
+                     This gate fires once per run."
+                ));
+            }
+
+            // FLUSH the merged cascade: every demand that fired above rides ONE round-trip. The
+            // premature assistant text is recorded once (content normalized to "" — an assistant
+            // turn with neither content nor tool_calls is malformed (400) on strict gateways), then
+            // a single user message carries all demands. With one demand the message is byte-equal
+            // to what the old per-gate loop sent.
+            if !demands.is_empty() {
                 messages.push(Message {
                     role: "assistant".to_string(),
                     content: Some(turn.content.clone().unwrap_or_default()),
@@ -1961,13 +1965,16 @@ where
                     images: Vec::new(),
                     cache_control: None,
                 });
-                messages.push(Message::user(format!(
-                    "{CONFIDENCE_GATE_PREFIX} You marked todo(s) done with a large confidence jump \
-                     without stepwise evidence.\n\n\
-                     Before finishing: re-run the relevant check (tests / verify / metric). \
-                     If checks pass, keep Done. If not, reopen the todo and fix.\n\
-                     This gate fires once per run."
-                )));
+                let combined = if demands.len() == 1 {
+                    demands.pop().expect("non-empty")
+                } else {
+                    format!(
+                        "Multiple checks fired on your \"done\" claim — address ALL of them in this \
+                         pass:\n\n{}",
+                        demands.join("\n\n---\n\n")
+                    )
+                };
+                messages.push(Message::user(combined));
                 iter += 1;
                 continue;
             }
@@ -2157,7 +2164,46 @@ where
         // with approval on THIS future. Eager starts from the streaming path are adopted by
         // position. Results land in ORIGINAL call order. (A DISCARDED turn — divergence/error —
         // simply drops its eager handles: detached, read-only, harmless.)
-        let eager = std::mem::take(&mut turn.eager);
+        let mut eager = std::mem::take(&mut turn.eager);
+        // IDENTICAL-RE-READ SHORT-CIRCUIT: a `file_read` whose canonical args exactly match an
+        // earlier call this run, whose file bytes are unchanged, and whose earlier result is still
+        // verbatim in history would return byte-identical content the model already has. Answer it
+        // with a one-line pointer instead — injected through the eager-adoption path so traces,
+        // ordering and cancellation stay uniform. (Measured sessions: 30% of tool calls re-hit a
+        // target already hit; the byte-identical subset is pure history bloat.) A real eager start
+        // for the same slot wins — its body already ran and its result is at least as good.
+        for (k, tc) in calls.iter().enumerate() {
+            if tc.function.name != "file_read" || eager.iter().any(|(i, _)| *i == k) {
+                continue;
+            }
+            let Some(entry) = read_cache.get(&canonical_args(&tc.function.arguments)) else {
+                continue;
+            };
+            let intact = messages.get(entry.msg_index).is_some_and(|m| {
+                m.role == "tool"
+                    && m.tool_call_id.as_deref() == Some(entry.call_id.as_str())
+                    && m.content.as_deref().is_some_and(|c| {
+                        c.chars().count() == entry.result_chars
+                            && c.starts_with(&entry.result_prefix)
+                    })
+            });
+            if !intact {
+                continue;
+            }
+            let unchanged = std::fs::read(&entry.path)
+                .map(|b| crate::core::persist::FileFingerprint::for_bytes(&b) == entry.fingerprint)
+                .unwrap_or(false);
+            if !unchanged {
+                continue;
+            }
+            let canned = format!(
+                "[unchanged] {} — identical to your earlier file_read this run; that result is \
+                 still in context above and the file has not changed since. Use what you already \
+                 have, or pass a different start/end for another slice.",
+                entry.path.display()
+            );
+            eager.push((k, tokio::task::spawn(async move { canned })));
+        }
         crate::core::recovery::set_phase(crate::core::recovery::RecoveryPhase::ExecutingTools);
         let results = execute_calls(
             registry,
@@ -2229,6 +2275,95 @@ where
             }
             // Track the latest list so the next boundary is measured against it, moved or not.
             phase_todos_before = phase_todos_after;
+        }
+
+        // Remember this turn's file_read answers for the identical-re-read short-circuit. Only from
+        // turns with NO destructive call: a write in the same turn could have rewritten the file
+        // AFTER the read ran (reads precede the write barrier), and a fingerprint taken now would
+        // then attest to content the cached result does not show. Read-only turns — the dribble
+        // pattern this exists for — all record.
+        let turn_has_write = calls.iter().any(|tc| {
+            registry
+                .get(&tc.function.name)
+                .map(|t| t.is_destructive())
+                .unwrap_or(true)
+        });
+        if !turn_has_write {
+            for (k, (tc, (call_id, result))) in calls.iter().zip(results.iter()).enumerate() {
+                if tc.function.name != "file_read"
+                    || result.starts_with("error:")
+                    || result.starts_with("[unchanged]")
+                {
+                    continue;
+                }
+                let Ok(args) = parse_call_args(&tc.function.arguments) else {
+                    continue;
+                };
+                // The batch (`files:[…]`) form mixes several files in one result — one fingerprint
+                // cannot attest to it. Only the single-path form is cached.
+                if args.get("files").is_some() {
+                    continue;
+                }
+                let Some(path) = args.get("path").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let Ok(resolved) =
+                    crate::agent::builtin::confine(&cfg.effective_root(), path, true)
+                else {
+                    continue;
+                };
+                let Ok(bytes) = std::fs::read(&resolved) else {
+                    continue;
+                };
+                if read_cache.len() >= 512 {
+                    read_cache.clear(); // bounded; a dropped entry only costs a re-read
+                }
+                read_cache.insert(
+                    canonical_args(&tc.function.arguments),
+                    ReadCacheEntry {
+                        path: resolved,
+                        fingerprint: crate::core::persist::FileFingerprint::for_bytes(&bytes),
+                        msg_index: base + k,
+                        call_id: call_id.clone(),
+                        result_chars: result.chars().count(),
+                        result_prefix: result.chars().take(48).collect(),
+                    },
+                );
+            }
+        }
+
+        // BATCH-COACH: three consecutive turns that each made exactly ONE read-only retrieval call
+        // is the dribble pattern the system prompt already warns about — name it mid-run, where the
+        // habit is visible. A system nudge rides the NEXT request (zero extra round-trips), once
+        // per run.
+        let is_read_lane = |name: &str| {
+            matches!(
+                name,
+                "file_read"
+                    | "search_files"
+                    | "file_glob"
+                    | "codebase_search"
+                    | "read_symbol"
+                    | "memory_search"
+                    | "web_fetch"
+                    | "web_search"
+            ) || name.starts_with("lsp_")
+        };
+        if calls.len() == 1 && is_read_lane(&calls[0].function.name) {
+            single_read_streak += 1;
+        } else {
+            single_read_streak = 0;
+        }
+        if !batch_nudged && single_read_streak >= BATCH_COACH_AFTER {
+            batch_nudged = true;
+            push_nudge(
+                messages,
+                NUDGE_BATCH,
+                "[batch] Your last few turns each made a single read-only call. Batch independent \
+                 reads/searches into ONE turn as parallel tool calls — file_read takes \
+                 files:[{path,start,end},…], search_files takes context:N — and sequence only when \
+                 one result decides the next call.",
+            );
         }
 
         // EVIDENCE / STALL GUARD: a turn is informative when it adds facts, changes the workspace, or
@@ -3683,6 +3818,26 @@ fn summarize_result(name: &str, out: &str) -> (bool, String) {
 /// Pagination fields (e.g. file_read's start/end) are DELIBERATELY kept: a different read window is
 /// different work; a re-read returning identical bytes is caught by the content-novelty thrash guard
 /// instead (stripping them would flag legit sequential paging as divergence).
+/// One remembered `file_read` answer for the identical-re-read short-circuit: enough to prove
+/// "this exact call, against this exact file content, already answered — and its answer is still
+/// verbatim in history". All legs must hold; any miss falls back to a normal read. A false
+/// negative costs nothing, a false positive would starve the model of content it needs — so every
+/// check is byte-level.
+struct ReadCacheEntry {
+    /// Resolved on-disk path, for the fingerprint re-check.
+    path: std::path::PathBuf,
+    /// Fingerprint of the file bytes the cached result described. Recorded only from turns with
+    /// NO destructive call, so it provably equals the content at read time (nothing in the same
+    /// turn could have rewritten the file between the read and the record).
+    fingerprint: crate::core::persist::FileFingerprint,
+    /// Where the result message sat when recorded — revalidated against id+len+prefix below, so a
+    /// shifted (compacted) or blanked (evicted) history can never false-match.
+    msg_index: usize,
+    call_id: String,
+    result_chars: usize,
+    result_prefix: String,
+}
+
 fn turn_signature(calls: &[ToolCall]) -> String {
     let mut sigs: Vec<String> = calls
         .iter()
@@ -4494,6 +4649,13 @@ const TODO_POKE_PREFIX: &str = "[todo-poke]";
 const CONFIDENCE_GATE_PREFIX: &str = "[confidence-gate]";
 /// P0.3 hill-climb reframe / remeasure (system nudge via push_nudge).
 const NUDGE_HILL_CLIMB: &str = "[hill-climb]";
+/// Batch-coach (system nudge via push_nudge, once per run): fires after several consecutive
+/// turns that each made exactly ONE read-only call — measured sessions dribble 91% single-call
+/// turns despite the system prompt asking for batching, so the reminder lands mid-run where the
+/// habit is visible, at zero extra round-trips.
+const NUDGE_BATCH: &str = "[batch]";
+/// Consecutive one-read-call turns before the batch coach speaks. Three is a pattern, not luck.
+const BATCH_COACH_AFTER: usize = 3;
 /// GOAL MODE poke (user role — hard block path): the model tried to stop without having declared
 /// completion via `goal_complete`, so we re-inject the goal text and keep it working. Mirrors the
 /// todo-poke gate's shape (a `user` message the model can't ignore), not a soft system nudge.
@@ -9332,6 +9494,176 @@ mod tests {
             "poke lists the open item"
         );
         todo::clear();
+    }
+
+    #[tokio::test]
+    async fn done_gates_merge_into_one_round_trip() {
+        // self-review (nudge mode) + incomplete todos both fire on the SAME "done" claim: the old
+        // cascade spent one LLM round-trip PER gate; the merged flush carries both demands in ONE
+        // combined user message, with each gate's budget/latch consumed exactly as before.
+        let _t = todo::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _h = crate::core::config::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        todo::set(vec![todo::Todo::new("open-item", todo::Status::Pending)]);
+        let r = registry();
+        let c = AgentConfig {
+            enable_self_review: true,
+            enable_todo_poke: true,
+            max_todo_poke_attempts: 1,
+            approval_mode: crate::core::approval::ApprovalMode::Yolo,
+            max_iters: 8,
+            auto_extend_to: 8,
+            ..cfg()
+        };
+        let mut messages = vec![Message::system("sys"), Message::user("edit something")];
+        let chat = scripted(vec![
+            tool_turn("delete", "{}"), // successful destructive op arms made_any_edits
+            final_turn("first done"),  // BOTH gates fire here — one merged message
+            final_turn("second done"), // both budgets spent → accepted
+        ]);
+        let out = run_agent_loop(chat, &c, &r, &mut messages).await.unwrap();
+        assert_eq!(out.stop, StopReason::Done);
+        assert_eq!(out.final_text.as_deref(), Some("second done"));
+        let merged: Vec<&Message> = messages
+            .iter()
+            .filter(|m| {
+                m.role == "user"
+                    && m.content
+                        .as_deref()
+                        .is_some_and(|c| c.starts_with("Multiple checks fired"))
+            })
+            .collect();
+        assert_eq!(merged.len(), 1, "one combined message, not one per gate");
+        let body = merged[0].content.as_deref().unwrap();
+        assert!(body.contains("[self-review]"), "{body}");
+        assert!(body.contains(TODO_POKE_PREFIX), "{body}");
+        // The old one-gate-one-message shape is gone: neither demand went out standalone.
+        assert!(
+            !messages.iter().any(|m| {
+                m.role == "user"
+                    && m.content.as_deref().is_some_and(|c| {
+                        c.starts_with("[self-review]") || c.starts_with(TODO_POKE_PREFIX)
+                    })
+            }),
+            "both demands rode the merged message"
+        );
+        assert_valid_history(&messages);
+        todo::clear();
+    }
+
+    /// A stub named `file_read` — the loop's re-read short-circuit and batch coach key on the tool
+    /// NAME, and the property under test is the LOOP's bookkeeping, not the real reader's slicing.
+    struct StubFileRead;
+    impl Tool for StubFileRead {
+        fn name(&self) -> &str {
+            "file_read"
+        }
+        fn description(&self) -> &str {
+            "stub file reader"
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type":"object","properties":{"path":{"type":"string"}},"required":["path"]})
+        }
+        fn execute(&self, args: &serde_json::Value) -> Result<String> {
+            let p = args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+            Ok(std::fs::read_to_string(p)?)
+        }
+    }
+
+    #[tokio::test]
+    async fn identical_re_read_short_circuits_only_while_unchanged() {
+        let dir = std::env::temp_dir().join(format!("aizen-reread-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("a.txt");
+        std::fs::write(&file, "alpha").unwrap();
+        let args = serde_json::json!({"path": file.to_string_lossy()}).to_string();
+        let mut r = ToolRegistry::new();
+        r.register(Box::new(StubFileRead));
+        let c = AgentConfig {
+            max_iters: 10,
+            auto_extend_to: 10,
+            ..cfg()
+        };
+        let mut messages = vec![Message::system("sys"), Message::user("read it")];
+        // Turn 1 reads. Turn 2 repeats the call byte-for-byte → short-circuited. Before turn 3 the
+        // CHAT CLOSURE rewrites the file, so the third identical call must fall through to a real
+        // read (the fingerprint leg fails) — a false "unchanged" here would starve the model.
+        let file_for_chat = file.clone();
+        let turns = Mutex::new(VecDeque::from(vec![
+            tool_turn("file_read", &args),
+            tool_turn("file_read", &args),
+            tool_turn("file_read", &args),
+            final_turn("done"),
+        ]));
+        let chat = move |_m: Vec<Message>, _d: Vec<ToolDef>| {
+            let mut q = turns.lock().unwrap();
+            if q.len() == 2 {
+                // about to hand out the THIRD call — change the file under it
+                std::fs::write(&file_for_chat, "beta").unwrap();
+            }
+            std::future::ready(Ok(q.pop_front().unwrap_or_else(|| final_turn("stop"))))
+        };
+        let out = run_agent_loop(chat, &c, &r, &mut messages).await.unwrap();
+        assert_eq!(out.stop, StopReason::Done);
+        let tool_bodies: Vec<&str> = messages
+            .iter()
+            .filter(|m| m.role == "tool")
+            .filter_map(|m| m.content.as_deref())
+            .collect();
+        assert_eq!(tool_bodies.len(), 3, "{tool_bodies:?}");
+        assert_eq!(tool_bodies[0], "alpha");
+        assert!(
+            tool_bodies[1].starts_with("[unchanged]"),
+            "byte-identical repeat of an unchanged file answers with a pointer: {}",
+            tool_bodies[1]
+        );
+        assert_eq!(
+            tool_bodies[2], "beta",
+            "a changed file must be re-read for real, never short-circuited"
+        );
+        assert_valid_history(&messages);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn batch_coach_nudges_once_after_a_single_read_streak() {
+        let dir = std::env::temp_dir().join(format!("aizen-batchcoach-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut turns = Vec::new();
+        for i in 0..4 {
+            let f = dir.join(format!("f{i}.txt"));
+            std::fs::write(&f, format!("body-{i}")).unwrap();
+            let args = serde_json::json!({"path": f.to_string_lossy()}).to_string();
+            turns.push(tool_turn("file_read", &args));
+        }
+        turns.push(final_turn("done"));
+        let mut r = ToolRegistry::new();
+        r.register(Box::new(StubFileRead));
+        let c = AgentConfig {
+            max_iters: 10,
+            auto_extend_to: 10,
+            ..cfg()
+        };
+        let mut messages = vec![Message::system("sys"), Message::user("survey the files")];
+        let out = run_agent_loop(scripted(turns), &c, &r, &mut messages)
+            .await
+            .unwrap();
+        assert_eq!(out.stop, StopReason::Done);
+        let coach_count = messages
+            .iter()
+            .filter(|m| {
+                m.content
+                    .as_deref()
+                    .is_some_and(|c| c.starts_with(NUDGE_BATCH))
+            })
+            .count();
+        // Fired at streak 3, latched thereafter — the 4th single read must not re-nudge.
+        assert_eq!(coach_count, 1, "one batch-coach nudge per run");
+        assert_valid_history(&messages);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Steering is a process-global mailbox (the keyboard thread has no handle on the running turn),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4789,11 +4789,18 @@ fn approve(tool: &str, args: &serde_json::Value, cfg: &AgentConfig) -> bool {
     // until it presses [y]es / [n]o / [a]llow-all-session. (Destructive tools force the serial path,
     // so we're on a tokio worker where block_in_place is valid — same invariant as the telegram bridge.)
     if crate::ui::tui::active() {
+        // Under the retained backend `ask_approval` raises a menu that carries the choices, so the
+        // transcript line only needs the question; keep the key legend for the fallback where no
+        // menu can be painted and y/n/a on the keyboard is the whole interface.
+        let hint = if crate::ui::tui::retained_running() {
+            "— approve?"
+        } else {
+            "— approve? [y]es · [n]o · [a]llow all this session"
+        };
         let prompt = format!(
             "{}  {}",
             tool_call_line(tool, args),
-            style("— approve? [y]es · [n]o · [a]llow all this session")
-                .color256(crate::ui::theme::WARN)
+            style(hint).color256(crate::ui::theme::WARN)
         );
         return tokio::task::block_in_place(|| crate::ui::tui::ask_approval(&prompt));
     }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -22,6 +22,7 @@ pub mod goal;
 pub mod lsp;
 pub mod mcp;
 pub mod mcp_oauth;
+pub mod mcp_serve;
 pub mod orchestration;
 pub mod process;
 pub mod project_context;
@@ -1216,21 +1217,40 @@ where
                     cfg.clear_step_pct,
                     cfg.clear_cooldown_iters,
                 ) {
-                    if let Ok((before, after)) =
-                        compact::compact_history(messages, summarize, compact::KEEP_TURNS).await
-                    {
-                        context_warned = false; // history shrank — let the wrap-up nudge re-arm if it refills
-                        budget_band_shown = None; // …and the running budget signal (P-ctx1)
-                        real_anchor = None; // spliced history invalidates the anchor
-                        stall.forget_successes(); // summarized-away results must not mark a re-read as stale
-                        est_now = estimate_tokens(messages) + schema_overhead;
-                        if !cfg.quiet {
-                            let line =
-                                format!("→ context: auto-compacted ~{before} → ~{after} tok");
-                            if crate::ui::tui::active() {
-                                crate::ui::tui::emit_line(&line);
-                            } else {
-                                eprintln!("{line}");
+                    match compact::compact_history(messages, summarize, compact::KEEP_TURNS).await {
+                        Ok((before, after)) => {
+                            context_warned = false; // history shrank — let the wrap-up nudge re-arm if it refills
+                            budget_band_shown = None; // …and the running budget signal (P-ctx1)
+                            real_anchor = None; // spliced history invalidates the anchor
+                            stall.forget_successes(); // summarized-away results must not mark a re-read as stale
+                            est_now = estimate_tokens(messages) + schema_overhead;
+                            if !cfg.quiet {
+                                let line =
+                                    format!("→ context: auto-compacted ~{before} → ~{after} tok");
+                                if crate::ui::tui::active() {
+                                    crate::ui::tui::emit_line(&line);
+                                } else {
+                                    eprintln!("{line}");
+                                }
+                            }
+                        }
+                        // A failed compaction used to vanish without a trace: the cadence latch
+                        // still armed below, so a down summarizer endpoint meant compaction was
+                        // silently skipped for the rest of the run while context kept climbing.
+                        // Say so — the user can fix the summarizer; nobody can fix what is hidden.
+                        Err(e) => {
+                            if !cfg.quiet {
+                                let line = format!(
+                                    "⚠ context: auto-compact failed ({e:#}) — continuing without \
+                                     it; history will rely on tool-result clearing only"
+                                );
+                                if crate::ui::tui::active() {
+                                    crate::ui::tui::emit_line(
+                                        &crate::ui::theme::faint(line).to_string(),
+                                    );
+                                } else {
+                                    eprintln!("{line}");
+                                }
                             }
                         }
                     }
@@ -1303,11 +1323,33 @@ where
         // indefinitely with growing backoff; permanent client errors (400/401/403/404) retry only a
         // few times (the provider may be briefly misbehaving) then surface the error. Esc still exits
         // cleanly every attempt via `cancel::race`. Ordinary turns keep the old fatal-on-error path.
+        // One emergency overflow shrink per iteration: the provider rejecting the request as too
+        // big is deterministic, so a second identical failure after a shrink means shrinking is
+        // not the answer — surface the error instead of thrashing.
+        let mut overflow_shrunk = false;
+
         let mut turn = if cfg.goal.is_some() {
             const GOAL_PERMANENT_RETRIES: u32 = 3;
+            // Patient but NOT eternal. Transient failures and empty-200s share this
+            // consecutive-failure ceiling (~30 min of backoff at the 30s plateau): while this
+            // inner loop spins, the wall-clock deadline at the loop TOP can never be reached, so
+            // an unbounded retry here made a dead endpoint pin a /goal run forever.
+            const GOAL_TRANSIENT_RETRIES: u32 = 60;
             let mut attempt: u32 = 0;
             let mut permanent_tries: u32 = 0;
             loop {
+                // The loop-top deadline check is unreachable while we spin here — honor it here
+                // too, with the same shape (no synthesis call on an already-elapsed ceiling).
+                if cfg.deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+                    if nudge_pushed {
+                        messages.pop();
+                    }
+                    return Ok(AgentOutcome {
+                        final_text: None,
+                        iters: iter,
+                        stop: StopReason::Deadline,
+                    });
+                }
                 match crate::core::cancel::race(&cfg.cancel, chat(messages.clone(), defs.clone()))
                     .await
                 {
@@ -1322,16 +1364,30 @@ where
                         });
                     }
                     Some(Ok(t)) => {
-                        // EMPTY-200: a 200 with neither content nor a tool call, and no completion
-                        // claimed this turn, is a silent provider failure — not a real "done". Retry
-                        // it with backoff rather than feeding an empty turn into the done cascade.
+                        // EMPTY-200: a 200 with neither content nor a tool call is a silent
+                        // provider failure — not a real "done". Retry it with backoff rather than
+                        // feeding an empty turn into the done cascade. A PENDING completion claim
+                        // (`goal_complete` fired on an earlier tool turn) used to excuse emptiness
+                        // outright — which reported a provider failure as a finished goal. Now the
+                        // claim only shortens the retry budget: the provider gets two fresh chances
+                        // to actually speak before the claim is accepted as the whole answer.
                         let empty_200 = t.tool_calls.is_empty()
                             && t.content
                                 .as_deref()
                                 .map(|s| s.trim().is_empty())
-                                .unwrap_or(true)
-                            && !goal::is_pending();
-                        if empty_200 {
+                                .unwrap_or(true);
+                        let excuse_as_goal_claim = goal::is_pending() && attempt >= 2;
+                        if empty_200 && !excuse_as_goal_claim {
+                            if attempt >= GOAL_TRANSIENT_RETRIES {
+                                if nudge_pushed {
+                                    messages.pop();
+                                }
+                                return Err(anyhow::anyhow!(
+                                    "provider returned {} empty response(s) in a row (HTTP 200 \
+                                     with no text and no tool call) — giving up this /goal turn",
+                                    attempt + 1
+                                ));
+                            }
                             let delay = crate::llm::client::goal_backoff_ms(attempt);
                             attempt += 1;
                             goal_retry_line(&format!("empty response; retry #{attempt}"), delay);
@@ -1350,6 +1406,25 @@ where
                         break t;
                     }
                     Some(Err(e)) => match crate::llm::client::classify_api_error(&e) {
+                        crate::llm::client::ApiErrorKind::ContextOverflow => {
+                            // The request outgrew the window — retrying it unchanged 4xxes
+                            // identically, and giving up abandons a run the transcript can save.
+                            // Shrink once, then retry immediately (the failure was deterministic,
+                            // not load — no backoff owed).
+                            if overflow_shrunk
+                                || !emergency_overflow_shrink(messages, &cfg, schema_overhead)
+                            {
+                                if nudge_pushed {
+                                    messages.pop();
+                                }
+                                return Err(e);
+                            }
+                            overflow_shrunk = true;
+                            real_anchor = None; // history shrank under the anchor's feet
+                            stall.forget_successes(); // evicted bodies must not mark re-reads stale
+                            est_now = estimate_tokens(messages) + schema_overhead;
+                            goal_retry_line("context overflow — cleared old tool results", 0);
+                        }
                         crate::llm::client::ApiErrorKind::Permanent => {
                             permanent_tries += 1;
                             if permanent_tries > GOAL_PERMANENT_RETRIES {
@@ -1376,6 +1451,12 @@ where
                             }
                         }
                         crate::llm::client::ApiErrorKind::Transient => {
+                            if attempt >= GOAL_TRANSIENT_RETRIES {
+                                if nudge_pushed {
+                                    messages.pop();
+                                }
+                                return Err(e);
+                            }
                             let delay = crate::llm::client::goal_backoff_ms(attempt);
                             attempt += 1;
                             goal_retry_line(&format!("API error; retry #{attempt}"), delay);
@@ -1450,6 +1531,17 @@ where
             let mut attempt: u32 = 0;
             let mut empty_nudges: usize = 0;
             loop {
+                // Same reason as the goal branch: the loop-top deadline check cannot fire while
+                // this retry loop spins, so a run that is out of time must stop HERE, not after
+                // the budget's worth of further 300s calls.
+                if cfg.deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+                    rollback(messages, empty_nudges, nudge_pushed);
+                    return Ok(AgentOutcome {
+                        final_text: None,
+                        iters: iter,
+                        stop: StopReason::Deadline,
+                    });
+                }
                 match crate::core::cancel::race(&cfg.cancel, chat(messages.clone(), defs.clone()))
                     .await
                 {
@@ -1511,6 +1603,32 @@ where
                         continue;
                     }
                     Some(Err(e)) => {
+                        // Overflow first: it is deterministic (retrying unchanged 4xxes
+                        // identically) but recoverable (the transcript can be shrunk). One shrink,
+                        // one immediate retry, no backoff — then the error is real.
+                        if matches!(
+                            crate::llm::client::classify_api_error(&e),
+                            crate::llm::client::ApiErrorKind::ContextOverflow
+                        ) {
+                            if overflow_shrunk
+                                || !emergency_overflow_shrink(messages, &cfg, schema_overhead)
+                            {
+                                rollback(messages, empty_nudges, nudge_pushed);
+                                return Err(e);
+                            }
+                            overflow_shrunk = true;
+                            real_anchor = None;
+                            stall.forget_successes();
+                            est_now = estimate_tokens(messages) + schema_overhead;
+                            if !cfg.quiet {
+                                retry_line(
+                                    "overflow",
+                                    "context overflow — cleared old tool results; retrying",
+                                    0,
+                                );
+                            }
+                            continue;
+                        }
                         let transient = matches!(
                             crate::llm::client::classify_api_error(&e),
                             crate::llm::client::ApiErrorKind::Transient
@@ -2151,16 +2269,21 @@ where
             // list (evidence the work isn't done) and on the run not ALSO being in a signature loop,
             // so a genuinely looping run still hard-stops. Budget-bounded: a run that goes flat again
             // after this stops for real.
+            // The open-plan gate applies only where the process-global todo list belongs to THIS
+            // run (`enable_todo_poke`). A sub-agent leaves that false because the list it would
+            // read is its PARENT's — so for it the recovery is gated on the budget and the
+            // signature latch alone. Without this, a delegated child always hard-stopped on its
+            // third flat turn with no recourse, however large the task it was handed.
+            let plan_still_open = !cfg.enable_todo_poke || todo::has_incomplete();
             if stall_recoveries < cfg.max_stall_recoveries
-                && cfg.enable_todo_poke
                 && nudged_sigs.is_empty()
-                && todo::has_incomplete()
+                && plan_still_open
             {
                 stall_recoveries += 1;
                 stall.recover();
                 if !cfg.quiet {
                     let line = format!(
-                        "→ stall recovery {}/{} — todos still open, changing approach instead of stopping",
+                        "→ stall recovery {}/{} — changing approach instead of stopping",
                         stall_recoveries, cfg.max_stall_recoveries
                     );
                     if crate::ui::tui::active() {
@@ -2169,14 +2292,20 @@ where
                         eprintln!("{line}");
                     }
                 }
-                let open = todo::incomplete_summary(600).unwrap_or_default();
+                let open_block = if cfg.enable_todo_poke {
+                    let open = todo::incomplete_summary(600).unwrap_or_default();
+                    format!(
+                        ", but your task list still has open items — so you are not finished.\n\n\
+                         Still open:\n{open}\n"
+                    )
+                } else {
+                    " and the task you were handed is not finished.\n".to_string()
+                };
                 messages.push(Message::user(format!(
-                    "{CONTINUE_PREFIX} Your last few attempts added no new evidence, but your task \
-                     list still has open items — so you are not finished.\n\n\
-                     Still open:\n{open}\n\n\
+                    "{CONTINUE_PREFIX} Your last few attempts added no new evidence{open_block}\n\
                      Do NOT retry the same approach again. Pick a genuinely different route (read the \
                      actual state instead of guessing, try another tool, narrow the problem), or — if \
-                     an item is truly impossible — say exactly why and mark it accordingly. \
+                     the work is truly impossible — say exactly why. \
                      Recovery {stall_recoveries}/{}.",
                     cfg.max_stall_recoveries
                 )));
@@ -2351,6 +2480,21 @@ where
 /// without oversubscribing. Not configurable in v1 (no measured need for a `--threads` flag).
 const MAX_PARALLEL: usize = 5;
 
+/// Wall-clock ceiling for one CONCURRENCY-SAFE (read-only) tool body — the executor's floor for
+/// tools that carry no timeout of their own (`file_read` on a dead network mount,
+/// `codebase_search` behind a wedged index lock). `AIZEN_TOOL_CALL_SECS`, clamped 30s..=3600s,
+/// default 600s: far above any healthy read, low enough that a hung one ends this run's turn
+/// instead of this run. Destructive tools are NOT under this ceiling — they run on the barrier
+/// path, where abandoning a body mid-write would lose its real outcome.
+fn safe_tool_ceiling() -> std::time::Duration {
+    let secs = std::env::var("AIZEN_TOOL_CALL_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(|v| v.clamp(30, 3600))
+        .unwrap_or(600);
+    std::time::Duration::from_secs(secs)
+}
+
 /// The pre-fill placeholder for a tool result whose call never completed (the turn future was
 /// dropped mid-batch by Esc). Honest AND pairing-valid — strict gateways accept the history.
 const INTERRUPTED_TOOL_PLACEHOLDER: &str = "error: interrupted before completion";
@@ -2497,6 +2641,18 @@ async fn execute_calls(
                             // The blocking body keeps running detached; safe calls are read-only,
                             // so discarding the result is harmless.
                             "error: cancelled by user".to_string()
+                        }
+                        // FLOOR CEILING for tools with no wall clock of their own (a hung network
+                        // file read, a stalled index lock). Same discard rationale as the cancel
+                        // arm: this path holds only read-only bodies, so abandoning the thread
+                        // loses nothing but the answer. Destructive tools run on the barrier path,
+                        // which stays deliberately un-raced — their real outcome must be recorded.
+                        _ = tokio::time::sleep(safe_tool_ceiling()) => {
+                            format!(
+                                "error: tool call exceeded {}s and was abandoned (set \
+                                 AIZEN_TOOL_CALL_SECS to raise the ceiling)",
+                                safe_tool_ceiling().as_secs()
+                            )
                         }
                     };
                     if adopted.contains(&k) && !cfg.quiet {
@@ -2779,9 +2935,17 @@ pub fn eager_starter<'a>(
             return None; // over the cap: run normally at execution time
         }
         let turn_cancel = cancel.clone();
+        let turn_ctx = cfg.exec_ctx.clone();
         Some(tokio::task::spawn_blocking(move || {
-            crate::core::cancel::with_current(turn_cancel, || {
-                run_tool_body(tool, &args, true, max_chars, max_fetch_chars)
+            // Seed BOTH thread-locals, exactly like the two normal execution arms. Cancel alone
+            // used to be seeded here, so an eager-started body saw `exec_ctx::current() == None`
+            // and resolved its conversation identity from the process-global slot — the same
+            // tool body could answer under two identities depending on whether its arguments
+            // finished streaming early enough for a head start.
+            crate::core::exec_ctx::with_current(turn_ctx, || {
+                crate::core::cancel::with_current(turn_cancel, || {
+                    run_tool_body(tool, &args, true, max_chars, max_fetch_chars)
+                })
             })
         }))
     }
@@ -2828,15 +2992,11 @@ fn gate_and_approve(
     // catastrophic command (rm -rf /, mkfs, dd to a raw device, fork bomb, curl|sh) is refused with
     // no override; `smart` mode may auto-clear a read-only command past the approval prompt.
     let mut smart_allow = false;
-    // Both `shell_run` and a background `process` start run an arbitrary command → guard them
-    // identically, so going background can't sidestep the floor.
-    let guarded_command: Option<&str> = match tool.name() {
-        "shell_run" => args.get("command").and_then(|v| v.as_str()),
-        "process" if args.get("action").and_then(|v| v.as_str()) == Some("start") => {
-            args.get("command").and_then(|v| v.as_str())
-        }
-        _ => None,
-    };
+    // Owned by the TOOL, not a name match here: `Tool::command_to_guard` is overridden by every
+    // tool that executes a model-supplied command (`shell_run`, `process start` — guarded
+    // identically so going background can't sidestep the floor). A hand-written match on two
+    // names used to fail OPEN for any future command-running tool.
+    let guarded_command: Option<String> = tool.command_to_guard(args);
     // `network: true` is a CAPABILITY ESCALATION, not a normal argument: the sandbox denies child
     // network by default (kernel-enforced where the platform can), so asking for it must always be
     // visible. `smart` never auto-clears it (only read-only-shaped commands are auto-cleared, and a
@@ -2859,7 +3019,7 @@ fn gate_and_approve(
             eprintln!("{line}");
         }
     }
-    if let Some(command) = guarded_command {
+    if let Some(command) = guarded_command.as_deref() {
         match cmd_guard::classify(command) {
             cmd_guard::Verdict::Blocked(reason) => {
                 let line = format!(
@@ -3852,6 +4012,35 @@ fn is_failure_result(content: &str) -> bool {
         return code.parse::<i64>().map(|n| n != 0).unwrap_or(false);
     }
     false
+}
+
+/// EMERGENCY OVERFLOW SHRINK — the recovery behind [`crate::llm::client::ApiErrorKind::ContextOverflow`].
+///
+/// The provider just rejected the request as too big, which means the chars/4 estimate that arms
+/// the ordinary clearing guard under-counted (code and non-Latin text both do this). Evict stale
+/// tool-result bodies down to HALF the window — or half the current size when the window is
+/// unknown — so the retry has real headroom rather than shaving just under a boundary the
+/// estimate cannot see. Returns whether anything was actually reclaimed; `false` means shrinking
+/// cannot save this run and the caller must surface the error.
+fn emergency_overflow_shrink(
+    messages: &mut [Message],
+    cfg: &AgentConfig,
+    schema_overhead: usize,
+) -> bool {
+    let raw = estimate_tokens(messages) + schema_overhead;
+    let target = if cfg.context_window > 0 {
+        (cfg.context_window / 2).min(raw / 2)
+    } else {
+        raw / 2
+    };
+    let stats = clear_tool_results_to_floor(
+        messages,
+        cfg.keep_recent_tool_results.max(1),
+        cfg.clear_tool_result_min_chars,
+        target,
+        schema_overhead,
+    );
+    stats.cleared + stats.failures_trimmed > 0
 }
 
 /// Batch-evict stale tool-result bodies until the running estimate (messages + `schema_overhead`)
@@ -5214,6 +5403,14 @@ mod tests {
         }
         fn is_destructive(&self) -> bool {
             true
+        }
+        fn command_to_guard(&self, args: &serde_json::Value) -> Option<String> {
+            // Part of the contract the stub stands in for: the hard floor keys on this method
+            // (not on the tool NAME), so a command-running stub must declare its command exactly
+            // like the real `shell_run` does.
+            args.get("command")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
         }
         fn execute(&self, _args: &serde_json::Value) -> Result<String> {
             Ok("RAN".into())

--- a/src/agent/orchestration.rs
+++ b/src/agent/orchestration.rs
@@ -79,9 +79,43 @@ struct RunManifest {
     started_unix: u64,
     finished_unix: Option<u64>,
     updated_unix: u64,
+    /// Who set this process running, when it was not a person at a terminal.
+    ///
+    /// Empty (and omitted from the file) for every ordinary run: a REPL turn, a one-shot `aizen`
+    /// invocation, the daemon. It is filled only by [`set_origin`], and today the only caller is
+    /// `aizen mcp serve`, which learns the name from the MCP handshake — so a fan-out that Claude
+    /// Code asked for says `Claude Code` because Claude Code said so, not because anything guessed.
+    ///
+    /// Readers must treat it as a label, never as authority: it is a string a client chose for
+    /// itself, so it may name a program that does not exist. It decides what a status view prints
+    /// and nothing else.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    origin: String,
 }
 
 const RUN_SCHEMA: u32 = 1;
+
+/* The origin, set at most once per process.
+`OnceLock` rather than a mutex on purpose: a process serves one client for its whole life, so the
+second caller is a bug rather than a change of mind, and a write that silently loses is a safer
+failure than a run whose author changes halfway through a fan-out. */
+static ORIGIN: OnceLock<String> = OnceLock::new();
+
+/// Name whoever is driving this process, for every run it starts from here on.
+///
+/// Ignored if called twice — see [`ORIGIN`]. The name is trimmed and bounded because it arrives
+/// over a wire from another program.
+pub fn set_origin(who: &str) {
+    let who = safe_text(who.trim(), 60);
+    if who.is_empty() {
+        return;
+    }
+    let _ = ORIGIN.set(who);
+}
+
+fn origin() -> String {
+    ORIGIN.get().cloned().unwrap_or_default()
+}
 
 fn manifest_root() -> PathBuf {
     crate::core::config::aizen_home()
@@ -144,6 +178,7 @@ fn persist_manifest(e: &Entry) {
         started_unix: e.started_unix,
         finished_unix: e.finished_unix,
         updated_unix: unix_now(),
+        origin: origin(),
     }) {
         Ok(bytes) => bytes,
         Err(_) => return,
@@ -260,16 +295,18 @@ struct Store {
 impl Store {
     fn push_live(&mut self, e: Entry) {
         if self.live.len() >= LIVE_SOFT_CAP {
-            // Drop the oldest finished-looking live row if any; else the oldest.
+            // Evict only a FINISHED row. Evicting a still-running one orphaned it: `finish` and
+            // `set_phase` search `live` only, so the evicted run's eventual finish became a
+            // silent no-op, its manifest was never removed, and other processes' `/workflows`
+            // showed a phantom "running" row for the whole stale-sweep window. A fan-out at the
+            // documented max (32 children + their parent) may briefly exceed the soft cap
+            // instead — the cap is a display bound, not a correctness bound.
             if let Some(i) = self
                 .live
                 .iter()
                 .position(|x| matches!(x.phase, Phase::Done | Phase::Failed))
             {
                 let old = self.live.remove(i);
-                self.push_history(old);
-            } else if !self.live.is_empty() {
-                let old = self.live.remove(0);
                 self.push_history(old);
             }
         }
@@ -284,7 +321,11 @@ impl Store {
         }
     }
 
-    fn finish(&mut self, id: u64, phase: Phase, detail: impl Into<String>) {
+    /// Returns whether the row existed — the CALLER then drops the cross-process manifest,
+    /// OUTSIDE the store lock. Manifest IO takes a 1–2s file lock; holding the store mutex
+    /// across it stalled every reader (`/workflows`, the HUD chip, `cancel_matching`) for the
+    /// duration of a contended write.
+    fn finish(&mut self, id: u64, phase: Phase, detail: impl Into<String>) -> bool {
         let detail = detail.into();
         if let Some(pos) = self.live.iter().position(|e| e.id == id) {
             let mut e = self.live.remove(pos);
@@ -294,23 +335,24 @@ impl Store {
             }
             e.finished = Some(Instant::now());
             e.finished_unix = Some(unix_now());
-            // Terminal state → drop the cross-process manifest (the remote view only surfaces
-            // running/synthesizing rows, so a finished file is dead weight and would otherwise
-            // linger until the stale sweep).
-            remove_manifest(e.id);
             self.push_history(e);
+            return true;
         }
+        false
     }
 
-    fn set_phase(&mut self, id: u64, phase: Phase, detail: impl Into<String>) {
+    /// Returns a snapshot of the updated row for the CALLER to persist — same reason as
+    /// [`Store::finish`]: the manifest write must not happen under this lock.
+    fn set_phase(&mut self, id: u64, phase: Phase, detail: impl Into<String>) -> Option<Entry> {
         let detail = detail.into();
         if let Some(e) = self.live.iter_mut().find(|e| e.id == id) {
             e.phase = phase;
             if !detail.is_empty() {
                 e.detail = detail;
             }
-            persist_manifest(e);
+            return Some(e.clone());
         }
+        None
     }
 }
 
@@ -328,28 +370,41 @@ impl Track {
 
     /// Mark successful completion (or a terminal non-error status like `max-iters` still "done-ish").
     pub fn finish_ok(mut self, detail: impl Into<String>) {
-        store()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .finish(self.id, Phase::Done, detail);
+        let found =
+            store()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .finish(self.id, Phase::Done, detail);
+        if found {
+            // Terminal state → drop the cross-process manifest, OUTSIDE the store lock (its file
+            // lock can block for seconds; see `Store::finish`).
+            remove_manifest(self.id);
+        }
         self.finished = true;
     }
 
     /// Mark failure / error.
     pub fn finish_err(mut self, detail: impl Into<String>) {
-        store()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .finish(self.id, Phase::Failed, detail);
+        let found = store().lock().unwrap_or_else(|e| e.into_inner()).finish(
+            self.id,
+            Phase::Failed,
+            detail,
+        );
+        if found {
+            remove_manifest(self.id);
+        }
         self.finished = true;
     }
 
     /// Update phase without finishing (e.g. workflow → synthesizing).
     pub fn set_phase(&self, phase: Phase, detail: impl Into<String>) {
-        store()
+        let snapshot = store()
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .set_phase(self.id, phase, detail);
+        if let Some(e) = snapshot {
+            persist_manifest(&e); // outside the lock — see `Store::set_phase`
+        }
     }
 
     /// Publish a stop handle for this run, so `/workflows stop <id>` can cancel it alone.
@@ -367,11 +422,14 @@ impl Track {
 impl Drop for Track {
     fn drop(&mut self) {
         if !self.finished {
-            store().lock().unwrap_or_else(|e| e.into_inner()).finish(
+            let found = store().lock().unwrap_or_else(|e| e.into_inner()).finish(
                 self.id,
                 Phase::Failed,
                 "aborted",
             );
+            if found {
+                remove_manifest(self.id);
+            }
         }
     }
 }
@@ -683,6 +741,35 @@ pub fn hud_chip() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /* The origin field must be invisible to everything that existed before it.
+    Two directions, both load-bearing: a manifest written by an older aizen (or by any ordinary
+    run today) has no `origin` key and must still parse, and a run with no origin must still
+    SERIALISE without the key — otherwise every `/workflows` row and every desktop office pane on
+    an older reader gains a field it was not built to ignore, for a value that is always empty. */
+    #[test]
+    fn a_manifest_without_an_origin_round_trips_unchanged() {
+        let old = r#"{"schema":1,"run_id":"7","pid":42,"kind":"task","name":"n","label":"l",
+            "phase":"running","detail":"","parent":null,"started_unix":1,"finished_unix":null,
+            "updated_unix":2}"#;
+        let m: RunManifest = serde_json::from_str(old).expect("an older manifest still parses");
+        assert!(m.origin.is_empty());
+        let back = serde_json::to_string(&m).unwrap();
+        assert!(
+            !back.contains("origin"),
+            "an ordinary run writes the same file it always did"
+        );
+    }
+
+    #[test]
+    fn a_manifest_carries_the_name_the_client_gave() {
+        let new = r#"{"schema":1,"run_id":"7","pid":42,"kind":"workflow","name":"n","label":"l",
+            "phase":"running","detail":"","parent":null,"started_unix":1,"finished_unix":null,
+            "updated_unix":2,"origin":"Claude Code"}"#;
+        let m: RunManifest = serde_json::from_str(new).unwrap();
+        assert_eq!(m.origin, "Claude Code");
+        assert!(serde_json::to_string(&m).unwrap().contains("Claude Code"));
+    }
 
     #[test]
     fn track_lifecycle_and_format() {

--- a/src/agent/process.rs
+++ b/src/agent/process.rs
@@ -470,6 +470,16 @@ impl Tool for Process {
             _ => WorkspaceEffect::None,
         }
     }
+    fn command_to_guard(&self, args: &Value) -> Option<String> {
+        // Only `start` executes a command; kill/logs/wait/write drive an existing handle. Guarded
+        // identically to `shell_run` so going background can't sidestep the hard floor.
+        if args.get("action").and_then(|v| v.as_str()) != Some("start") {
+            return None;
+        }
+        args.get("command")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    }
     fn execute(&self, args: &Value) -> Result<String> {
         let action = args
             .get("action")

--- a/src/agent/search.rs
+++ b/src/agent/search.rs
@@ -28,6 +28,9 @@ const MAX_LINE_CHARS: usize = 240;
 /// Hard wall-clock cap so a search over a giant tree can't freeze the agent loop (the parallel walk
 /// checks this per file and quits every thread once it trips).
 const SEARCH_TIMEOUT: Duration = Duration::from_secs(10);
+/// Cap on `context` — ±10 lines already shows a whole function around most matches; more is a
+/// file read wearing a search costume.
+const MAX_CONTEXT: usize = 10;
 
 /// Decode a file's bytes to searchable text, detecting UTF-16 (P2.2). A UTF-16-encoded source file
 /// (common on Windows — PowerShell `>` redirection, some editors, .NET logs) is `byte,0,byte,0…`,
@@ -94,11 +97,11 @@ impl Tool for SearchFiles {
         "search_files"
     }
     fn description(&self) -> &str {
-        "Search file CONTENT by regular expression. Defaults to the working directory but `path` may \
-         be a ../ or absolute directory elsewhere. By default respects .gitignore and skips hidden + \
-         binary files; set hidden:true to also search hidden files and ignored/build dirs. Returns \
-         `path:line: matched text`. This is the canonical content search — do NOT shell out to \
-         grep/ripgrep, and do NOT use file_glob (that matches file NAMES, not content). Read-only."
+        "Search file CONTENT by regular expression (`path` may be a ../ or absolute dir elsewhere). \
+         Respects .gitignore and skips hidden + binary files unless hidden:true. Returns \
+         `path:line: matched text`; context:N adds ±N surrounding lines (grep -C) so a follow-up \
+         file_read is rarely needed. The canonical content search — do NOT shell out to \
+         grep/ripgrep; file_glob matches NAMES, not content. Read-only."
     }
     fn parameters(&self) -> Value {
         serde_json::json!({
@@ -110,7 +113,8 @@ impl Tool for SearchFiles {
                 "glob": {"type": "string", "description": "optional file glob to restrict which files are searched, e.g. *.rs or src/**/*.ts"},
                 "ignore_case": {"type": "boolean", "description": "case-insensitive match (default false)"},
                 "hidden": {"type": "boolean", "description": "also search hidden files and .gitignored paths (default false)"},
-                "max_results": {"type": "integer", "description": "cap on matches returned (default 200)"}
+                "max_results": {"type": "integer", "description": "cap on matches returned (default 200)"},
+                "context": {"type": "integer", "description": "lines of context around each match, grep -C style (default 0, max 10)"}
             },
             "required": ["pattern"]
         })
@@ -128,6 +132,11 @@ impl Tool for SearchFiles {
             .get("max_results")
             .and_then(|v| v.as_u64())
             .unwrap_or(DEFAULT_MAX_RESULTS as u64) as usize;
+        let ctx = args
+            .get("context")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+            .min(MAX_CONTEXT as u64) as usize;
         let re = RegexBuilder::new(pattern)
             .case_insensitive(ignore_case)
             .build()
@@ -165,7 +174,12 @@ impl Tool for SearchFiles {
         // over a huge tree can't freeze the agent loop. Results, the match counter, and the
         // skipped-large-file counter are shared behind a `Mutex`/atomics. Per-file work (read →
         // binary/UTF-16 classify → line-scan) happens on the worker thread.
-        let results: Mutex<Vec<(PathBuf, usize, String)>> = Mutex::new(Vec::new());
+        // Per file: (path, rows), each row = (1-based line, clipped text, is_match). With
+        // context=0 the rows are exactly the match lines (the classic flat shape); with context>0
+        // they are the MERGED ±ctx windows around the matches, so an overlapping pair of matches
+        // never prints a line twice.
+        type FileRows = (PathBuf, Vec<(usize, String, bool)>);
+        let results: Mutex<Vec<FileRows>> = Mutex::new(Vec::new());
         let files_hit = AtomicUsize::new(0);
         let match_count = AtomicUsize::new(0);
         let skipped_large = AtomicUsize::new(0);
@@ -208,35 +222,68 @@ impl Tool for SearchFiles {
                     .strip_prefix(&self.root)
                     .unwrap_or(dent.path())
                     .to_path_buf();
-                let mut this_file = false;
+                // Pass 1: collect this file's match line numbers (1-based) under the global cap.
+                let mut hit_lines: Vec<usize> = Vec::new();
                 for (i, line) in text.lines().enumerate() {
                     if re.is_match(line) {
-                        this_file = true;
-                        let trimmed = line.trim_end();
-                        let shown: String = if trimmed.chars().count() > MAX_LINE_CHARS {
-                            trimmed.chars().take(MAX_LINE_CHARS).collect::<String>() + "…"
-                        } else {
-                            trimmed.to_string()
-                        };
                         let n = match_count.fetch_add(1, Ordering::Relaxed);
                         if n >= max_results {
                             truncated.store(true, Ordering::Relaxed);
                             break;
                         }
-                        results.lock().unwrap().push((rel.clone(), i + 1, shown));
+                        hit_lines.push(i + 1);
                     }
                 }
-                if this_file {
-                    files_hit.fetch_add(1, Ordering::Relaxed);
+                if hit_lines.is_empty() {
+                    return WalkState::Continue;
                 }
+                files_hit.fetch_add(1, Ordering::Relaxed);
+                // Pass 2: materialize rows — the match lines alone, or their merged ±ctx windows.
+                let lines: Vec<&str> = text.lines().collect();
+                let clip = |line: &str| -> String {
+                    let trimmed = line.trim_end();
+                    if trimmed.chars().count() > MAX_LINE_CHARS {
+                        trimmed.chars().take(MAX_LINE_CHARS).collect::<String>() + "…"
+                    } else {
+                        trimmed.to_string()
+                    }
+                };
+                let rows: Vec<(usize, String, bool)> = if ctx == 0 {
+                    hit_lines
+                        .iter()
+                        .map(|&n| (n, clip(lines[n - 1]), true))
+                        .collect()
+                } else {
+                    let mut windows: Vec<(usize, usize)> = Vec::new();
+                    for &n in &hit_lines {
+                        let s = n.saturating_sub(ctx).max(1);
+                        let e = (n + ctx).min(lines.len());
+                        match windows.last_mut() {
+                            // Merge overlapping/adjacent windows so no line prints twice.
+                            Some((_, prev_end)) if s <= *prev_end + 1 => {
+                                *prev_end = (*prev_end).max(e)
+                            }
+                            _ => windows.push((s, e)),
+                        }
+                    }
+                    let hits: std::collections::HashSet<usize> =
+                        hit_lines.iter().copied().collect();
+                    windows
+                        .iter()
+                        .flat_map(|&(s, e)| {
+                            (s..=e).map(|n| (n, clip(lines[n - 1]), hits.contains(&n)))
+                        })
+                        .collect()
+                };
+                results.lock().unwrap().push((rel, rows));
                 WalkState::Continue
             })
         });
 
         let mut results = results.into_inner().unwrap();
         // The parallel walk collects in nondeterministic order; sort so output is stable/readable.
-        results.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
-        results.truncate(max_results);
+        // (Rows within a file are already in line order — built by one worker in one pass.)
+        results.sort_by(|a, b| a.0.cmp(&b.0));
         let files_hit = files_hit.load(Ordering::Relaxed);
         let skipped_large = skipped_large.load(Ordering::Relaxed);
 
@@ -253,11 +300,28 @@ impl Tool for SearchFiles {
             }
             return Ok(msg);
         }
-        let lines: Vec<String> = results
+        let shown_matches: usize = results
             .iter()
-            .map(|(rel, n, shown)| format!("{}:{}: {}", rel.display(), n, shown))
-            .collect();
-        let mut out = format!("{} match(es) in {files_hit} file(s):", lines.len());
+            .map(|(_, rows)| rows.iter().filter(|r| r.2).count())
+            .sum();
+        // grep's own convention: `path:line:` marks a MATCH row, `path-line-` a context row, `--`
+        // separates non-contiguous groups — a shape every model already knows how to read.
+        let mut lines: Vec<String> = Vec::new();
+        for (rel, rows) in &results {
+            let mut prev: Option<usize> = None;
+            for (n, shown, is_match) in rows {
+                if !lines.is_empty() && ctx > 0 && prev.is_none_or(|p| *n != p + 1) {
+                    lines.push("--".to_string());
+                }
+                if *is_match {
+                    lines.push(format!("{}:{}: {}", rel.display(), n, shown));
+                } else {
+                    lines.push(format!("{}-{}- {}", rel.display(), n, shown));
+                }
+                prev = Some(*n);
+            }
+        }
+        let mut out = format!("{shown_matches} match(es) in {files_hit} file(s):");
         out.push('\n');
         out.push_str(&lines.join("\n"));
         if truncated.load(Ordering::Relaxed) {
@@ -383,6 +447,51 @@ mod tests {
             .execute(&serde_json::json!({"pattern": "secret"}))
             .unwrap();
         assert!(out.contains("cfg.ts"), "utf-16 file searched: {out}");
+    }
+
+    #[test]
+    fn context_lines_wrap_matches_and_merge_overlapping_windows() {
+        let root = tmp("context");
+        // Lines 1..=12; matches at 4 and 6 (windows ±2 overlap → ONE merged group 2..=8) and at 12.
+        let body = (1..=12)
+            .map(|i| {
+                if i == 4 || i == 6 || i == 12 {
+                    format!("needle line {i}")
+                } else {
+                    format!("plain line {i}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(root.join("ctx.txt"), body).unwrap();
+        let t = SearchFiles::new(root);
+        let out = t
+            .execute(&serde_json::json!({"pattern": "needle", "context": 2}))
+            .unwrap();
+        assert!(
+            out.starts_with("3 match(es) in 1 file(s):"),
+            "header counts MATCHES, not rows: {out}"
+        );
+        // Match rows use `path:line:`, context rows `path-line-` (grep -C convention).
+        assert!(out.contains("ctx.txt:4: needle line 4"), "{out}");
+        assert!(out.contains("ctx.txt-3- plain line 3"), "{out}");
+        // Overlapping windows merged: line 5 (between the 4 and 6 matches) appears exactly once.
+        assert_eq!(out.matches("plain line 5").count(), 1, "{out}");
+        // Non-contiguous groups separated by `--`: the 2..=8 block vs the 10..=12 block.
+        assert!(out.contains("--"), "{out}");
+        assert!(
+            !out.contains("plain line 9"),
+            "gap line outside both windows: {out}"
+        );
+        // context:0 (default) keeps the classic flat shape.
+        let flat = t2_flat(&t);
+        assert!(flat.contains("ctx.txt:4: needle line 4"), "{flat}");
+        assert!(!flat.contains("-3-"), "no context rows by default: {flat}");
+    }
+
+    fn t2_flat(t: &SearchFiles) -> String {
+        t.execute(&serde_json::json!({"pattern": "needle"}))
+            .unwrap()
     }
 
     #[test]

--- a/src/agent/system_prompt.md
+++ b/src/agent/system_prompt.md
@@ -46,7 +46,8 @@ Do the whole loop this turn. Don't hand back at the first obstacle — diagnose 
 - Take the next concrete step instead of describing it. Batch independent steps into ONE turn
   (parallel calls): reads and searches of any kind. A turn may mix one edit or command with reads —
   writes run in order, the round-trips still merge. Only sequence when one call's output feeds the
-  next.
+  next. Even a single call can batch: `file_read files:[{path,start,end},…]` reads several slices
+  at once, and `search_files context:N` returns surrounding lines so no follow-up read is needed.
 - Example — "fix the failing parse test": a good FIRST turn is three calls at once — search for the
   function, read the test file, read the source file — not three separate turns.
 

--- a/src/agent/system_prompt_strict.md
+++ b/src/agent/system_prompt_strict.md
@@ -15,8 +15,9 @@ is attached to the request. Call nothing that is not in that list.
    read the file. Don't guess paths, contents, or APIs. Use the file-finding tool, NEVER a shell
    `where` / `dir /s` / `Get-ChildItem -Recurse` / `find` / `fd` (slow on big trees, not always
    installed).
-4. Batch independent reads/searches into ONE turn (parallel calls). Only sequence when one call's
-   output feeds the next.
+4. Batch independent reads/searches into ONE turn (parallel calls); `file_read files:[…]` reads
+   several slices in one call, `search_files context:N` includes surrounding lines. Only sequence
+   when one call's output feeds the next.
 5. Read before you edit. Prefer rewriting a whole named item by symbol over hunting exact strings;
    for a small region copy the surrounding text EXACTLY; batch several edits to one file into ONE
    call. NEVER create, blank, or overwrite a file through the shell (redirection, `Set-Content`,

--- a/src/agent/task_tool.rs
+++ b/src/agent/task_tool.rs
@@ -627,12 +627,24 @@ impl Tool for TaskTool {
         }
         // Concurrency gate: each sub-agent is a whole model loop — cap how many run at once
         // (below the tool-level MAX_PARALLEL: N loops × N tool threads oversubscribes a CLI).
-        // Over-limit is a SOFT error the model recovers from by retrying serially.
-        let Some(_slot) = SubagentSlot::try_acquire() else {
-            return Ok(
-                "error: sub-agent concurrency limit reached — retry with fewer task calls in one turn"
-                    .to_string(),
-            );
+        // Over-limit is a SOFT error the model recovers from by retrying serially; a BROKEN gate
+        // (unwritable home) is a hard one, and the wording must not invite a retry that cannot
+        // ever succeed.
+        let _slot = match SubagentSlot::try_acquire() {
+            Ok(s) => s,
+            Err(SlotDenied::Full) => {
+                return Ok(
+                    "error: sub-agent concurrency limit reached — retry with fewer task calls in one turn"
+                        .to_string(),
+                );
+            }
+            Err(SlotDenied::Io(e)) => {
+                return Ok(format!(
+                    "error: the sub-agent gate is unavailable on this machine ({e}) — this is NOT \
+                     a concurrency limit and retrying will not help; tell the user their aizen \
+                     home directory appears unwritable or locked"
+                ));
+            }
         };
         let prompt = args
             .get("prompt")
@@ -749,7 +761,11 @@ impl Tool for TaskTool {
             // This delegated run owns one total budget; the core loop's own extension is the only
             // budget grant. Keep its continuation controls off so no second layer can multiply it.
             max_continuations: 0,
-            max_stall_recoveries: 0,
+            // ONE stall recovery, not zero. With zero, a delegated child hard-stopped on its third
+            // uninformative turn with no recourse at all — the top level gets a todo-gated recovery,
+            // and the loop grants a child (todo_poke off) the same single bounded chance without
+            // consulting the parent's todo list.
+            max_stall_recoveries: 1,
             // The deadline is absolute for this one run; it cannot be refreshed by a continuation.
             deadline: subagent_wall_deadline(),
             ..AgentConfig::default()
@@ -799,10 +815,11 @@ impl Tool for TaskTool {
         // pass-through there. Never call `execute` from a plain `#[test]` past the early-return
         // guards (no runtime).
         //
-        // CONTINUATION: the loop is driven over ONE persistent conversation so a budget exhaustion
-        // can be resumed rather than restarted. `run_agent_loop` appends every turn (and, on
-        // MaxIters, its own synthesized summary) to `msgs`, so re-entering with a `[continue]` user
-        // turn keeps the sub-agent's whole context: its plan, its tool results, its edits.
+        // ONE conversation for the whole run: every budget grant the core loop makes (the near-limit
+        // extension, retry nudges) continues over `msgs` with full context. There is NO cross-call
+        // resume — once `execute` returns, the transcript is gone, and a parent that wants more must
+        // dispatch fresh. That is why both exits below hand the parent a partial report built from
+        // `msgs` while it still exists: it is the only continuation surface there is.
         let outcome = tokio::task::block_in_place(|| {
             let _effort = crate::core::cli_config::suppress_effort_override();
             tokio::runtime::Handle::current().block_on(async {
@@ -815,10 +832,15 @@ impl Tool for TaskTool {
                             .iter()
                             .filter(|m| m.role == "assistant" && !m.tool_calls.is_empty())
                             .count();
+                        // The transcript dies with this return — salvage the same partial report
+                        // the Ok path gets. Without it, a child that completed 20 tool turns and
+                        // then hit a terminal API error handed the parent one line and no list of
+                        // what it had already touched.
+                        let partial = partial_report_from_messages(&msgs);
                         return Err(e.context(format!(
                             "after {completed_tool_turns} completed tool turn(s) — the workspace \
                              may already contain partial edits from this sub-agent; inspect before \
-                             retrying"
+                             retrying.\nPartial progress before the failure:\n{partial}"
                         )));
                     }
                 };
@@ -905,8 +927,9 @@ impl Tool for TaskTool {
 }
 
 /// Deterministic fallback when a child stops without a final answer. Uses only bounded, redacted
-/// facts already present in the transcript — no extra model call after the deadline.
-fn partial_report_from_messages(msgs: &[Message]) -> String {
+/// facts already present in the transcript — no extra model call after the deadline. Shared with
+/// the workflow runner (`workflow::run_one_task`), whose children stop the same ways.
+pub(crate) fn partial_report_from_messages(msgs: &[Message]) -> String {
     const MAX_ITEMS: usize = 12;
     const MAX_TEXT: usize = 800;
     let mut targets = Vec::new();
@@ -1044,10 +1067,23 @@ impl TaskTool {
         let model = model.to_string();
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                crate::llm::client::chat_with_tools(&client, &base, &key, &model, &[sys, usr], &[])
-                    .await
-                    .ok()
-                    .and_then(|t| t.content)
+                // Same ceiling + cancel discipline as the main chat closure. This call runs AFTER
+                // `run_agent_loop` returned, where neither `cfg.deadline` (a loop-boundary check)
+                // nor the loop's own per-call timeout can reach it — and the sub-agent SLOT is
+                // still held by the caller. Unbounded, a gateway that answers 200 and then drips
+                // here reproduced the exact permanent-slot-strand `SUBAGENT_CALL_TIMEOUT` exists
+                // to prevent: the slot held for the process lifetime, every later dispatch refused.
+                let deadline = subagent_call_timeout();
+                let cancel = crate::core::cancel::current().unwrap_or_default();
+                let msgs = [sys, usr];
+                let call =
+                    crate::llm::client::chat_with_tools(&client, &base, &key, &model, &msgs, &[]);
+                match crate::core::cancel::race(&cancel, tokio::time::timeout(deadline, call)).await
+                {
+                    Some(Ok(Ok(t))) => t.content,
+                    // Timeout, API error, or cancellation — repair is best-effort by contract.
+                    _ => None,
+                }
             })
         })
     }
@@ -1060,22 +1096,29 @@ impl TaskTool {
 /// but they do not mutate repository/workspace state and remain parallel-safe. Repository metadata
 /// writers such as `checkpoint` are excluded from the read-only base entirely.
 pub(crate) fn dispatch_is_read_only(r: &crate::agent::tools::ToolRegistry) -> bool {
-    // Includes symbolic-edit tools granted to coder/specialist sub-agents (see
-    // `register_subagent_lsp`). Missing them here would mis-classify a writer as read-only and let
-    // two symbol_replace dispatches race in parallel.
-    const WRITERS: &[&str] = &[
-        "file_edit",
-        "file_write",
-        "file_move",
-        "shell_run",
-        "skill_save",
-        // One name now covers save/rewind/restore (the read-only `checkpoint_view` is not a writer).
-        "checkpoint",
-        "symbol_replace",
-        "symbol_insert",
-    ];
     WRITERS.iter().all(|w| r.get(w).is_none())
 }
+
+/// The workspace-writing tool names `dispatch_is_read_only` denies on. Includes symbolic-edit
+/// tools granted to coder/specialist sub-agents (see `register_subagent_lsp`) — missing them here
+/// would mis-classify a writer as read-only and let two symbol_replace dispatches race in
+/// parallel. This is a DENYLIST, so an unlisted new writer fails OPEN; the
+/// `writers_denylist_covers_every_destructive_role_tool` test below is what turns that silent
+/// drift into a build failure.
+pub(crate) const WRITERS: &[&str] = &[
+    "file_edit",
+    "file_write",
+    "file_move",
+    "shell_run",
+    // `process` can `action=start` an arbitrary command — command execution is workspace-write
+    // capability even though today it only ever ships alongside `shell_run`.
+    "process",
+    "skill_save",
+    // One name now covers save/rewind/restore (the read-only `checkpoint_view` is not a writer).
+    "checkpoint",
+    "symbol_replace",
+    "symbol_insert",
+];
 
 /// Live count of in-flight sub-agents (process-global; both `task` and the workflow tool draw
 /// from real OS/model resources, so the cap is global too).
@@ -1135,33 +1178,69 @@ pub(crate) struct SubagentSlot {
     _global: crate::core::repo_lock::RepoTxnLock,
 }
 
+/// Why the gate refused a slot. The two causes need OPPOSITE caller behavior, and the old
+/// `Option` collapsed them: a process whose `aizen_home` was unwritable was told "concurrency
+/// limit reached — retry", which for that cause is an invitation to loop forever.
+#[derive(Debug)]
+pub(crate) enum SlotDenied {
+    /// Every slot is genuinely held — soft; the model may retry with fewer calls, or later.
+    Full,
+    /// The slot directory itself is unusable (unwritable home, deleted dir, AV holding the
+    /// files). Permanent for this process: a retry cannot help.
+    Io(String),
+}
+
 impl SubagentSlot {
-    pub(crate) fn try_acquire() -> Option<Self> {
+    pub(crate) fn try_acquire() -> Result<Self, SlotDenied> {
         use std::sync::atomic::Ordering;
         let cap = max_parallel_subagents();
         let prev = ACTIVE_SUBAGENTS.fetch_add(1, Ordering::SeqCst);
         if prev >= cap {
             ACTIVE_SUBAGENTS.fetch_sub(1, Ordering::SeqCst);
-            return None;
+            return Err(SlotDenied::Full);
         }
-        let start = (std::process::id() as usize + prev) % cap;
+        // Probe the whole GLOBAL band, not `0..cap`. The slot files are shared by every aizen
+        // process on this machine, while `cap` is this process's own width — with mismatched
+        // caps, a cap-2 process probing only slots 0–1 starved behind a cap-16 process holding
+        // exactly those two, with the rest of the band free. The per-process cap is enforced by
+        // the atomic above; the files exist to make a slot exclusive machine-wide, not to
+        // re-derive a cross-process cap from whichever process happens to probe.
+        let start = (std::process::id() as usize + prev) % HARD_CEILING;
         let root = crate::core::config::aizen_home()
             .join("locks")
             .join("v1")
             .join("slots")
             .join("subagents");
-        for step in 0..cap {
-            let idx = (start + step) % cap;
+        let mut saw_busy = false;
+        let mut io_err: Option<String> = None;
+        for step in 0..HARD_CEILING {
+            let idx = (start + step) % HARD_CEILING;
             let path = root.join(format!("slot-{idx}.lock"));
-            if let Ok(global) = crate::core::repo_lock::RepoTxnLock::acquire_exclusive(
+            match crate::core::repo_lock::RepoTxnLock::acquire_exclusive(
                 &path,
                 std::time::Duration::ZERO,
             ) {
-                return Some(Self { _global: global });
+                Ok(global) => return Ok(Self { _global: global }),
+                Err(e)
+                    if e.downcast_ref::<crate::core::repo_lock::LockBusy>()
+                        .is_some() =>
+                {
+                    saw_busy = true;
+                }
+                Err(e) => {
+                    if io_err.is_none() {
+                        io_err = Some(format!("{e:#}"));
+                    }
+                }
             }
         }
         ACTIVE_SUBAGENTS.fetch_sub(1, Ordering::SeqCst);
-        None
+        match (saw_busy, io_err) {
+            // Not one slot was even contested and every attempt failed on I/O: the gate itself
+            // is broken, not full.
+            (false, Some(e)) => Err(SlotDenied::Io(e)),
+            _ => Err(SlotDenied::Full),
+        }
     }
 
     /// Greedily reserve UP TO `want` slots (used by the `workflow` fan-out, which runs several
@@ -1170,7 +1249,7 @@ impl SubagentSlot {
     /// had free (0..=want); an empty Vec means the caller should degrade to a soft "gate full"
     /// error. Each slot releases on drop, so the whole batch frees when the returned Vec drops.
     pub(crate) fn acquire_up_to(want: usize) -> Vec<Self> {
-        (0..want).map_while(|_| Self::try_acquire()).collect()
+        (0..want).map_while(|_| Self::try_acquire().ok()).collect()
     }
 }
 
@@ -1432,6 +1511,41 @@ mod tests {
     }
 
     #[test]
+    fn writers_denylist_covers_every_destructive_role_tool() {
+        // `dispatch_is_read_only` is a DENYLIST: a destructive tool missing from `WRITERS`
+        // silently classifies its registry read-only — parallel-safe, verify gate off, and
+        // allowed through a no-`--yes` `mcp serve`. This sweep turns that drift into a failure:
+        // every destructive tool in every role registry must be a known workspace WRITER or a
+        // known OUTWARD tool (side effects land outside the workspace — aizen's own stores,
+        // notifications — so two of them cannot race on repository state).
+        const OUTWARD_OK: &[&str] = &[
+            "memory_forget",
+            "memory_save",
+            "memory_update",
+            "skill_refine",
+            "skill_forget",
+            "skill_install",
+            "notify",
+            "telegram_send",
+        ];
+        let root = std::env::current_dir().unwrap();
+        for role in ["planner", "reviewer", "coder", "tester"] {
+            let reg = crate::agent::builtin::role_registry(role, &root);
+            for tool in reg.tools() {
+                if tool.is_destructive() {
+                    let name = tool.name();
+                    assert!(
+                        WRITERS.contains(&name) || OUTWARD_OK.contains(&name),
+                        "destructive tool `{name}` (role {role}) is in neither WRITERS nor \
+                         OUTWARD_OK — classify it, or `dispatch_is_read_only` will call its \
+                         registry read-only"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn subagent_gate_caps_reserves_and_releases() {
         // Process-global counter — serialize against any other test that might touch ACTIVE_SUBAGENTS.
         // (Default cargo --test-threads>1 races two gate tests on the same atomic.)
@@ -1462,7 +1576,7 @@ mod tests {
         let a = SubagentSlot::try_acquire().expect("slot 1");
         let b = SubagentSlot::try_acquire().expect("slot 2");
         let c = SubagentSlot::try_acquire().expect("slot 3");
-        assert!(SubagentSlot::try_acquire().is_none(), "cap of 3 enforced");
+        assert!(SubagentSlot::try_acquire().is_err(), "cap of 3 enforced");
         drop(b);
         let d = SubagentSlot::try_acquire().expect("released slot reusable");
         drop(a);
@@ -1475,7 +1589,7 @@ mod tests {
         let batch = SubagentSlot::acquire_up_to(5);
         assert_eq!(batch.len(), 3, "capped at the default cap of 3");
         assert!(
-            SubagentSlot::try_acquire().is_none(),
+            SubagentSlot::try_acquire().is_err(),
             "gate is full after a maxed reservation"
         );
         drop(batch);

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -81,6 +81,15 @@ pub trait Tool: Send + Sync {
     fn recovery_effect(&self, args: &Value) -> bool {
         self.is_destructive() || self.workspace_effect(args) != WorkspaceEffect::None
     }
+    /// The shell command line this call would EXECUTE, when this tool runs commands at all. The
+    /// loop's hard `cmd_guard` floor and the network-escalation notice key on this — it used to be
+    /// a hand-written name match in the executor, which meant a future command-running tool
+    /// silently received no floor. Owning it here makes the guard travel with the capability:
+    /// override in every tool that spawns a model-supplied command; the default `None` means
+    /// "executes nothing".
+    fn command_to_guard(&self, _args: &Value) -> Option<String> {
+        None
+    }
     /// Run the tool. `args` is the parsed (object) arguments. Return the result text; return
     /// an `Err` for a real failure — the loop feeds the error back to the model to recover.
     fn execute(&self, args: &Value) -> Result<String>;

--- a/src/agent/verify_gate.rs
+++ b/src/agent/verify_gate.rs
@@ -199,6 +199,12 @@ pub async fn run_verify_gate(cwd: &Path, timeout_secs: u64) -> Option<VerifyGate
     let custom_timeout = custom_verify_timeout(cwd);
     let mut last_pass: Option<VerifyGateResult> = None;
     for cmd in cmds {
+        // The gate can hold the turn for minutes per command; it must not be the one region Esc
+        // cannot reach. Between commands is the cheap, safe boundary — `run_one_verify` also
+        // races its wait against this token.
+        if crate::core::cancel::current().is_some_and(|c| c.is_cancelled()) {
+            return None; // best-effort by contract; the loop's own cancel check ends the run
+        }
         let secs = match cmd {
             VerifyCommand::Custom(_) => custom_timeout.unwrap_or(timeout_secs),
             _ => timeout_secs,
@@ -251,8 +257,26 @@ async fn run_one_verify(
     let containment = sbx.contain_tokio(&child);
     let dur = Duration::from_secs(timeout_secs.max(1));
     // `wait_with_output` consumes the child, so the tree is killed through the containment handle
-    // rather than a `&mut Child` we no longer have.
-    let outcome = timeout(dur, child.wait_with_output()).await;
+    // rather than a `&mut Child` we no longer have. The wait is ALSO raced against the turn's
+    // cancel token: a verify command can hold the turn for minutes, and this used to be the one
+    // long region Esc could not reach — the user watched a `cargo check` they had already
+    // abandoned run to completion.
+    let cancel = crate::core::cancel::current();
+    let waited = timeout(dur, child.wait_with_output());
+    let outcome = match &cancel {
+        Some(c) => {
+            tokio::select! {
+                o = waited => Some(o),
+                _ = c.cancelled() => None,
+            }
+        }
+        None => Some(waited.await),
+    };
+    let Some(outcome) = outcome else {
+        crate::core::proctree::terminate_tree(&containment);
+        sbx.finish(crate::sandbox::runner::Outcome::Cancelled);
+        return None; // best-effort: the loop's own cancel check ends the run right after
+    };
     if outcome.is_err() {
         crate::core::proctree::terminate_tree(&containment);
     }

--- a/src/agent/workflow.rs
+++ b/src/agent/workflow.rs
@@ -20,7 +20,7 @@
 
 use crate::agent::builtin::{agent_registry, role_registry};
 use crate::agent::task_tool::{build_agent_subagent_prompt, build_subagent_prompt};
-use crate::agent::{run_agent, AgentConfig, StopReason};
+use crate::agent::{run_agent_loop, AgentConfig, StopReason};
 use crate::core::types::{Message, ToolDef};
 use crate::llm::client::{chat_with_tools, stream_chat_with_visual_contract};
 use anyhow::{anyhow, bail, Context, Result};
@@ -192,17 +192,25 @@ async fn run_workflow_with_cancel(
         );
     }
 
-    if results.iter().any(|r| r.status == "cancelled") {
+    // Only the PARENT token ends the whole workflow. A cancelled CHILD (`/workflows stop #id`)
+    // is a per-task outcome: the stop surface promises "siblings keep running", and honoring
+    // that means keeping their finished results too — bailing here used to discard every
+    // sibling's completed work over one stopped child.
+    if cancel.is_cancelled() {
         wf_track.finish_err("cancelled");
         bail!("workflow '{}': cancelled by user", spec.name);
     }
 
-    // If every task errored there is nothing to synthesize — don't spend a synthesis call
-    // feeding the model only "error: …" strings.
-    if results.iter().all(|r| r.status == "error") {
-        wf_track.finish_err("all tasks failed");
+    // If every task errored or was stopped there is nothing to synthesize — don't spend a
+    // synthesis call feeding the model only "error: …" strings.
+    if results
+        .iter()
+        .all(|r| matches!(r.status.as_str(), "error" | "cancelled"))
+    {
+        wf_track.finish_err("all tasks failed or were stopped");
         bail!(
-            "workflow '{}': all {} task(s) failed (see per-task errors above) — nothing to synthesize",
+            "workflow '{}': all {} task(s) failed or were stopped (see per-task lines above) — \
+             nothing to synthesize",
             spec.name,
             results.len()
         );
@@ -311,7 +319,10 @@ pub(crate) fn task_is_writer(role: &str, agent: Option<&str>) -> bool {
             Some(def) => !crate::agent::task_tool::dispatch_is_read_only(
                 &crate::agent::builtin::agent_registry(&def, std::path::Path::new(".")),
             ),
-            None => true, // unresolvable slug → runner uses coder scope → treat as a writer
+            // Unresolvable slug → treat as a writer. Conservative on purpose: the RUNNER falls
+            // back to the task's ROLE scope (default `reviewer`, read-only), so over-counting
+            // here can only refuse/serialize a dispatch that was safe — never the reverse.
+            None => true,
         };
     }
     matches!(role, "coder" | "tester")
@@ -483,14 +494,19 @@ pub(crate) async fn run_workflow_collect(
     .await;
     drop(slots); // explicit: hold the reservation across the whole fan-out, free it here
 
-    if results.iter().any(|r| r.status == "cancelled") {
+    // Same rule as the CLI runner above: only the PARENT token ends the workflow. One stopped
+    // child is a per-task status line; its siblings' results survive into the report/synthesis.
+    if cancel.is_cancelled() {
         wf_track.finish_err("cancelled");
         bail!("workflow '{}': cancelled by user", spec.name);
     }
-    if results.iter().all(|r| r.status == "error") {
-        wf_track.finish_err("all tasks failed");
+    if results
+        .iter()
+        .all(|r| matches!(r.status.as_str(), "error" | "cancelled"))
+    {
+        wf_track.finish_err("all tasks failed or were stopped");
         bail!(
-            "workflow '{}': all {} task(s) failed — nothing to report",
+            "workflow '{}': all {} task(s) failed or were stopped — nothing to report",
             spec.name,
             results.len()
         );
@@ -766,9 +782,11 @@ async fn run_one_task(
         // error used to reduce a whole child's work to `status: "error"` in the synthesis input.
         max_transient_retries: CHILD_TRANSIENT_RETRIES,
         // A workflow child has one total budget; do not present partial work from a multiplied budget.
-        // Stall recovery stays off because it reads the process-global todo list, not ScopedTodo.
         max_continuations: 0,
-        max_stall_recoveries: 0,
+        // ONE stall recovery, same as a `task` child: with todo_poke off the loop grants it
+        // without consulting the (parent-owned) process-global todo list, so a child that goes
+        // flat gets one bounded change-of-approach turn instead of dying on the spot.
+        max_stall_recoveries: 1,
         // The PARENT's resolved window, so tool-result clearing and the wrap-up guard are ON for a
         // child (the clearing/guard knobs themselves come from `AgentConfig::default()` below, which
         // already carries the production percentages — they are inert while this is 0).
@@ -817,7 +835,14 @@ async fn run_one_task(
         wf_trace(&format!("⋯ {} ({label}) {subject} …", task.id));
     }
 
-    match run_agent(chat, &cfg, &registry, &system, &task.prompt).await {
+    // Drive the loop over a LOCAL transcript (what `run_agent` did internally) so both exits
+    // below can hand synthesis a deterministic partial report instead of "(no final answer)" —
+    // a child that hit its deadline after twenty tool turns still reports which files it touched.
+    let mut msgs = vec![
+        Message::system(system.as_str()),
+        Message::user(task.prompt.as_str()),
+    ];
+    match run_agent_loop(chat, &cfg, &registry, &mut msgs).await {
         Ok(o) => {
             let status = match o.stop {
                 StopReason::Done => "done",
@@ -845,13 +870,16 @@ async fn run_one_task(
                 role: label.clone(),
                 model: result_model.clone(),
                 status: status.to_string(),
-                summary: o.final_text.unwrap_or_else(|| {
-                    if status == "cancelled" {
-                        "cancelled by user".to_string()
-                    } else {
-                        "(no final answer)".to_string()
-                    }
-                }),
+                summary: o
+                    .final_text
+                    .filter(|s| !s.trim().is_empty())
+                    .unwrap_or_else(|| {
+                        if status == "cancelled" {
+                            "cancelled by user".to_string()
+                        } else {
+                            crate::agent::task_tool::partial_report_from_messages(&msgs)
+                        }
+                    }),
                 iters: o.iters,
             }
         }
@@ -863,7 +891,10 @@ async fn run_one_task(
                 role: label.clone(),
                 model: result_model.clone(),
                 status: "error".to_string(),
-                summary: format!("error: {e}"),
+                summary: format!(
+                    "error: {e}\nPartial progress before the failure:\n{}",
+                    crate::agent::task_tool::partial_report_from_messages(&msgs)
+                ),
                 iters: 0,
             }
         }

--- a/src/cli/run_cmds.rs
+++ b/src/cli/run_cmds.rs
@@ -328,6 +328,15 @@ pub(crate) async fn run_agent_cmd(args: AgentArgs) -> Result<()> {
     if args.task.trim().is_empty() {
         anyhow::bail!("empty task (pass the task as the first argument)");
     }
+    // Read before the endpoint is resolved, so a mistyped path costs a failed open rather than a
+    // billed request. Loud rather than skipped: this is the scripting and CI entry point, and an
+    // attachment that quietly vanished would produce a confident answer about an image the model
+    // never saw — the one failure mode a vision flag must not have.
+    let images = args
+        .image
+        .iter()
+        .map(|p| crate::ui::image_input::image_file_to_data_url(p))
+        .collect::<Result<Vec<_>>>()?;
     let (base_url, api_key, model) = resolve_endpoint(args.base_url, args.api_key, args.model)?;
     let http = http_client()?;
 
@@ -419,7 +428,18 @@ pub(crate) async fn run_agent_cmd(args: AgentArgs) -> Result<()> {
     // The transcript is built here rather than inside `run_agent` so this path can still hold it
     // afterwards: the loop appends every turn — the final answer included — to the vector it is
     // handed, and `run_agent` is exactly these two opening messages plus that call.
-    let mut history = vec![Message::system(&system), Message::user(args.task.trim())];
+    // One user turn either way. With attachments it serializes as a parts array (text first, then
+    // one image_url part each) instead of a plain string, which is the only difference on the wire.
+    let asked = if images.is_empty() {
+        Message::user(args.task.trim())
+    } else {
+        eprintln!(
+            "{}",
+            style(format!("📎 {} image(s) attached", images.len())).dim()
+        );
+        Message::user_with_images(args.task.trim(), images)
+    };
+    let mut history = vec![Message::system(&system), asked];
     let result = agent::run_agent_loop(chat, &cfg, &registry, &mut history).await;
     // Saved before the error is propagated. A run that ended badly still happened, and the REPL
     // treats persistence as not optional — that promise should not be weaker off a terminal.

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -1043,6 +1043,12 @@ pub(crate) struct AgentArgs {
     /// `reasoning_effort` is used, exactly as before. This flag never writes the config.
     #[arg(long, value_parser = ["auto", "low", "medium", "high", "xhigh", "max"])]
     pub(crate) effort: Option<String>,
+    /// Attach an image for the model to SEE — PNG/JPEG/GIF/WebP, up to 8 MB each. Repeat the flag
+    /// for more than one. Needs a vision-capable model: the file is inlined into the first user
+    /// message as an `image_url` data part, the same shape the REPL's drag-drop and Ctrl-O
+    /// attach produce. A path that is not a readable image fails the run rather than being dropped.
+    #[arg(long = "image", value_name = "PATH")]
+    pub(crate) image: Vec<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -332,6 +332,14 @@ pub(crate) enum McpCmd {
     Trust,
     /// Stop trusting this repo's project MCP servers.
     Untrust,
+    /// Run AS an MCP server on stdio, so another agent (Claude Code, Codex, Cursor…) can dispatch
+    /// aizen's specialists. Serves the repo it is started in.
+    Serve {
+        /// Allow dispatches that can edit files or run shell. Without it the server refuses any
+        /// coder/tester role and any specialist whose card grants a destructive tool.
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/core/cli_config.rs
+++ b/src/core/cli_config.rs
@@ -1629,12 +1629,21 @@ mod tests {
 
     #[test]
     fn auto_copy_defaults_on_and_honours_field_and_env() {
+        // `AIZEN_HOME` is process-global, so every test that repoints it takes this lock — without
+        // it this test and any concurrently running home-sandboxed test clobber each other's home
+        // and one of the two fails, whichever loses the race. `EnvGuard` restores `AIZEN_AUTO_COPY`
+        // so an ambient value on the developer's machine survives the run.
+        let _g = crate::core::config::TEST_HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _restore = crate::core::config::EnvGuard::unset(["AIZEN_AUTO_COPY"]);
         // Isolate from the developer's real ~/.aizen and any ambient AIZEN_AUTO_COPY.
         let dir = std::env::temp_dir().join(format!("aizen-auto-copy-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        std::env::set_var("AIZEN_HOME", &dir);
-        std::env::remove_var("AIZEN_AUTO_COPY");
+        // Guarded, not a raw set_var: this directory is deleted at the end of the test, so leaving
+        // AIZEN_HOME pointing at it would hand every later test a home that does not exist.
+        let _home = crate::core::config::EnvGuard::set([("AIZEN_HOME", &dir)]);
 
         // Never touched → ON (browser-like default the feature shipped with).
         assert!(auto_copy_enabled());

--- a/src/llm/client.rs
+++ b/src/llm/client.rs
@@ -125,7 +125,7 @@ fn apply_cache_breakpoints(messages: &mut [Message], tools: &mut [ToolDef]) {
 }
 
 impl CostMeter {
-    fn record(&self, u: &Usage) {
+    pub(crate) fn record(&self, u: &Usage) {
         // Only count a call as "real" if it carried at least one token field.
         if u.prompt_tokens.is_none() && u.completion_tokens.is_none() && u.total_tokens.is_none() {
             return;
@@ -541,8 +541,16 @@ async fn parse_models_body(resp: reqwest::Response) -> Result<Vec<ModelInfo>> {
 
 /// Transient upstream statuses worth a retry (rate-limit + gateway/server errors). A permanent 4xx
 /// (auth, bad request) is NOT here — retrying it just wastes a round-trip and money.
-fn is_retryable_status(status: u16) -> bool {
-    matches!(status, 429 | 500 | 502 | 503 | 504)
+///
+/// Beyond the obvious five: 408 (the server timed us out — same shape as a transport timeout),
+/// 425 (told to come back later), 522/524 (Cloudflare's origin-timeout pair, common in front of
+/// self-hosted endpoints), and 529 — Anthropic's own "Overloaded" status, which used to skip this
+/// fast `Retry-After`-aware layer and surface as a fatal error.
+pub(crate) fn is_retryable_status(status: u16) -> bool {
+    matches!(
+        status,
+        408 | 425 | 429 | 500 | 502 | 503 | 504 | 522 | 524 | 529
+    )
 }
 
 /// Exponential backoff CEILING (ms): `base * 2^attempt`, capped, floored at 1. Pure + monotonic so
@@ -672,7 +680,7 @@ fn stream_retry_note(reason: &str, attempt: u32, max: u32, delay_ms: u64) {
 
 /// Full-jitter backoff: a uniform delay in `[ceil/2, ceil]`. Jitter spreads retries so a fleet of
 /// callers doesn't thunder back in lock-step after a shared 503.
-fn backoff_ms(attempt: u32, base_ms: u64, cap_ms: u64) -> u64 {
+pub(crate) fn backoff_ms(attempt: u32, base_ms: u64, cap_ms: u64) -> u64 {
     let ceil = backoff_ceiling_ms(attempt, base_ms, cap_ms);
     let half = ceil / 2;
     half + (rand_u64() % (ceil - half + 1))
@@ -702,10 +710,29 @@ where
     const MAX_RETRIES: u32 = 3;
     const BASE_MS: u64 = 400;
     const CAP_MS: u64 = 8_000;
+    // TOTAL wall-clock budget for one logical send, retries and backoff included. This is the only
+    // ceiling on the PRE-response phase: the endpoint deliberately has no whole-request `.timeout()`
+    // (a streamed response lives longer than any sane value), and `read_timeout` fires per READ —
+    // a gateway that completes the handshake and then trickles held a call for up to 4×300s before
+    // this existed, and the loop above multiplied that by its own retries. Generous on purpose: a
+    // non-streaming completion legitimately spends its whole generation time before headers arrive.
+    let budget = send_total_budget();
+    let start = std::time::Instant::now();
     let mut attempt: u32 = 0;
     loop {
-        match build().send().await {
-            Ok(resp) => {
+        let remaining = budget.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            bail!(
+                "request exceeded the {}s total send budget (no response headers) — timeout",
+                budget.as_secs()
+            );
+        }
+        match tokio::time::timeout(remaining, build().send()).await {
+            Err(_) => bail!(
+                "request exceeded the {}s total send budget (no response headers) — timeout",
+                budget.as_secs()
+            ),
+            Ok(Ok(resp)) => {
                 let status = resp.status();
                 if status.is_success() {
                     return Ok(resp);
@@ -720,7 +747,7 @@ where
                 let detail = resp.text().await.unwrap_or_default();
                 bail!("upstream returned HTTP {status}: {detail}");
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 if attempt < MAX_RETRIES {
                     let delay = backoff_ms(attempt, BASE_MS, CAP_MS);
                     attempt += 1;
@@ -733,6 +760,17 @@ where
     }
 }
 
+/// The total send budget: `AIZEN_SEND_BUDGET_SECS` clamped to 60s..=3600s, default 600s. The floor
+/// keeps a typo from strangling every call; the ceiling keeps a typo from disabling the guard.
+fn send_total_budget() -> std::time::Duration {
+    let secs = std::env::var("AIZEN_SEND_BUDGET_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(|v| v.clamp(60, 3600))
+        .unwrap_or(600);
+    std::time::Duration::from_secs(secs)
+}
+
 /// Classification of a `chat()` error for GOAL MODE's smart retry (see the goal loop in
 /// `src/agent/mod.rs`). Goal mode keeps working through API flakiness, but must distinguish a
 /// transient upstream hiccup (retry indefinitely with backoff) from a permanent client error (bad
@@ -743,24 +781,66 @@ where
 pub enum ApiErrorKind {
     /// 429 / 5xx / transport / timeout / mid-stream drop — safe to retry indefinitely with backoff.
     Transient,
-    /// 400 / 401 / 403 / 404 — a client/config error retrying can't fix. Goal mode retries a small
-    /// bounded number of times (the provider may be briefly misbehaving) then stops with the error.
+    /// 4xx client/config errors retrying can't fix (auth, bad request, payment, unprocessable).
+    /// Goal mode retries a small bounded number of times (the provider may be briefly misbehaving)
+    /// then stops with the error.
     Permanent,
+    /// The request was too big for the model's window — a 413, or a 400 whose body says so.
+    /// Neither retrying (it will 4xx identically) nor giving up (the transcript can be shrunk) is
+    /// right: the loop's recovery is an emergency clear/compact, then ONE more try.
+    ContextOverflow,
 }
 
-/// Classify a `chat()` error for goal-mode retry. `send_with_retry` surfaces upstream failures as
-/// `upstream returned HTTP {status}: …` (where `{status}` renders like `400 Bad Request`) and
+/// Classify a `chat()` error for loop-level retry. `send_with_retry` surfaces upstream failures as
+/// `upstream returned HTTP {status}: {body}` (where `{status}` renders like `400 Bad Request`) and
 /// transport failures as `request failed after retries`; the streaming path adds `SSE stream error:
-/// …`. We match the permanent 4xx shapes and treat everything else as Transient — goal mode's whole
-/// point is surviving a flaky API, so the default leans toward retrying, not giving up.
+/// …`. Overflow is tested FIRST because it arrives wearing a permanent status (400/413) while having
+/// its own recovery. After that the real status number decides; anything without one — transport,
+/// timeout, stream drop — is Transient, because goal mode's whole point is surviving a flaky API.
 pub fn classify_api_error(e: &anyhow::Error) -> ApiErrorKind {
     let msg = e.to_string();
-    for code in ["HTTP 400", "HTTP 401", "HTTP 403", "HTTP 404"] {
-        if msg.contains(code) {
-            return ApiErrorKind::Permanent;
-        }
+    if is_overflow_message(&msg) {
+        return ApiErrorKind::ContextOverflow;
     }
-    ApiErrorKind::Transient
+    match extract_http_status(&msg) {
+        // 413 without an overflow-shaped body is still "the request is too large" for a chat
+        // call — same recovery. 402 (billing), 422 (unprocessable), 451 (blocked) used to fall
+        // through to Transient and burn every retry the budget had.
+        Some(413) => ApiErrorKind::ContextOverflow,
+        // The transient 4xx trio comes BEFORE the blanket 4xx arm: 429 is the single most common
+        // retryable status there is.
+        Some(408 | 425 | 429) => ApiErrorKind::Transient,
+        Some(400..=499) => ApiErrorKind::Permanent,
+        // 5xx and any parsed status that isn't a client error: worth another try.
+        Some(_) => ApiErrorKind::Transient,
+        None => ApiErrorKind::Transient,
+    }
+}
+
+/// The first `HTTP {digits}` in a rendered error message, as produced by `send_with_retry`.
+fn extract_http_status(msg: &str) -> Option<u16> {
+    let rest = &msg[msg.find("HTTP ")? + 5..];
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// Does this error body say the prompt outgrew the model's window? Providers word it differently;
+/// the phrases below cover OpenAI (`context_length_exceeded`, "maximum context length"), Anthropic
+/// ("prompt is too long"), and the common gateway paraphrases. Deliberately narrow — a false
+/// positive here would shrink a healthy transcript on an unrelated 400.
+fn is_overflow_message(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    [
+        "context_length_exceeded",
+        "context length",
+        "maximum context",
+        "prompt is too long",
+        "input is too long",
+        "too many tokens",
+        "exceeds the maximum number of tokens",
+    ]
+    .iter()
+    .any(|phrase| m.contains(phrase))
 }
 
 /// Full-jitter backoff (ms) for GOAL MODE's loop-level retry, indexed by attempt. Reuses the exact
@@ -835,7 +915,12 @@ async fn send_chat(
         body.reasoning_effort = None;
     }
     let had_effort = body.reasoning_effort.is_some();
-    match send_with_retry(|| client.post(url).bearer_auth(api_key).json(&body)).await {
+    // `with_provider_auth`, NOT bare `bearer_auth`: Anthropic's native surface wants
+    // `x-api-key` + `anthropic-version`, and OpenCode zen wants `x-opencode-client`. The
+    // `/models` probe already sent them — the actual chat traffic must not be the one path
+    // that forgets. The host test parses the host out of the full URL, so passing the chat
+    // URL (not the base) is fine.
+    match send_with_retry(|| with_provider_auth(client.post(url), url, api_key).json(&body)).await {
         Ok(r) => Ok(r),
         Err(e) => {
             let msg = e.to_string();
@@ -852,7 +937,8 @@ async fn send_chat(
                 } else {
                     eprintln!("{}", crate::ui::theme::faint(note));
                 }
-                send_with_retry(|| client.post(url).bearer_auth(api_key).json(&body)).await
+                send_with_retry(|| with_provider_auth(client.post(url), url, api_key).json(&body))
+                    .await
             } else {
                 Err(e)
             }
@@ -960,11 +1046,15 @@ pub async fn stream_chat_with_visual_contract(
     // BYTES, which keepalive frames defeat entirely. No replay here: this one-shot surface has no
     // eager handles to detach and its caller already prints the error.
     let stall = stream_stall_timeout();
+    // Re-armed only by frames that PARSE, same as the tool-calling path: a `data: {"type":"ping"}`
+    // keepalive reaches this loop as an event but must not keep a dead turn alive.
+    let mut last_useful = std::time::Instant::now();
     // Rate-limit counter, same reason as the tool-calling path: a delta shape we mis-model breaks
     // EVERY frame, and one warn per token buries the reply.
     let mut bad_frames: usize = 0;
     loop {
-        let event = match tokio::time::timeout(stall, stream.next()).await {
+        let remaining = stall.saturating_sub(last_useful.elapsed());
+        let event = match tokio::time::timeout(remaining, stream.next()).await {
             Ok(Some(Ok(e))) => e,
             Ok(Some(Err(e))) => {
                 stream_err = Some(anyhow!("SSE stream error: {e}"));
@@ -990,6 +1080,14 @@ pub async fn stream_chat_with_visual_contract(
 
         match parse_chunk(&event.data) {
             Ok(chunk) => {
+                last_useful = std::time::Instant::now();
+                // Same final-chunk-only guard as the tool-calling path: without it, `aizen chat`
+                // turns were invisible to `/cost` — the one surface that never recorded usage.
+                if let Some(u) = &chunk.usage {
+                    if chunk.choices.is_empty() {
+                        cost_meter().record(u);
+                    }
+                }
                 if let Some(choice) = chunk.choices.first() {
                     if let Some(content) = &choice.delta.content {
                         spin.take(); // clear before the first token prints
@@ -1474,17 +1572,28 @@ pub async fn stream_chat_with_tools_eager(
         let mut stream_err: Option<anyhow::Error> = None;
         // IDLE WATCHDOG. `reqwest`'s `read_timeout` fires only on a socket that delivers no BYTES; a
         // gateway that keeps the connection warm with comment/keepalive frames, or an upstream that
-        // stalls after `role`, satisfies it forever — so the turn hung with no cap at all. Bound the gap
-        // between USEFUL events instead, and re-arm the timer on every one.
+        // stalls after `role`, satisfies it forever — so the turn hung with no cap at all. Bound the
+        // gap between USEFUL events instead: the clock re-arms only when a frame PARSES into a chunk
+        // (`last_useful` below), so a gateway that pings with `data: {"type":"ping"}` frames — which
+        // reach this loop as events but carry nothing — cannot keep a dead turn alive. (Comment-style
+        // `: ping` keepalives never surface as events at all; this closes the data-frame variant.)
         let idle_cap = stream_stall_timeout();
+        let mut last_useful = std::time::Instant::now();
         // Has this stream produced anything a retry would duplicate? Text, a tool-call fragment, or a
         // usage report all count. Governs both the watchdog's error wording and blank-stream replay.
         let mut produced = false;
+        // The reasoning channel, accumulated but never displayed. If the model puts its whole answer
+        // there and leaves `content` empty — the historical "provider spoke, we reported silence" bug,
+        // fixed on the non-streaming path in `resolve_content` — the streaming path must not
+        // re-introduce it. Deliberately NOT counted as `produced`: nothing from this buffer reaches
+        // the display or history mid-stream, so a replay after a mid-reasoning stall duplicates nothing.
+        let mut reasoning = String::new();
         // Unparseable frames seen this stream. Counted so the warn can be rate-limited: the shape that
         // breaks parsing usually breaks EVERY frame, which is one line per token over the live UI.
         let mut bad_frames: usize = 0;
         loop {
-            let event = match tokio::time::timeout(idle_cap, stream.next()).await {
+            let remaining = idle_cap.saturating_sub(last_useful.elapsed());
+            let event = match tokio::time::timeout(remaining, stream.next()).await {
                 Ok(Some(Ok(e))) => e,
                 Ok(Some(Err(e))) => {
                     stream_err = Some(anyhow!("SSE stream error: {e}"));
@@ -1514,10 +1623,11 @@ pub async fn stream_chat_with_tools_eager(
             }
             match parse_chunk(&event.data) {
                 Ok(chunk) => {
-                    // Record usage ONLY on the final chunk (choices empty). Spec-compliant OpenAI sends
-                    // usage=null until then, but some gateways (vLLM/LiteLLM/OpenRouter) attach a
-                    // CUMULATIVE usage object to EVERY chunk — without this guard an N-chunk stream sums it
-                    // N times and inflates /cost (and calls_with_usage) ~N×.
+                    last_useful = std::time::Instant::now(); // a real chunk re-arms the watchdog
+                                                             // Record usage ONLY on the final chunk (choices empty). Spec-compliant OpenAI sends
+                                                             // usage=null until then, but some gateways (vLLM/LiteLLM/OpenRouter) attach a
+                                                             // CUMULATIVE usage object to EVERY chunk — without this guard an N-chunk stream sums it
+                                                             // N times and inflates /cost (and calls_with_usage) ~N×.
                     if let Some(u) = &chunk.usage {
                         if chunk.choices.is_empty() {
                             cost_meter().record(u);
@@ -1527,10 +1637,22 @@ pub async fn stream_chat_with_tools_eager(
                     }
                     if let Some(choice) = chunk.choices.first() {
                         // A dedicated reasoning channel (`reasoning_content`/`reasoning`) is the model
-                        // thinking out loud — suppress it entirely so output is uniform across models.
+                        // thinking out loud — suppressed from the display so output is uniform across
+                        // models, but ACCUMULATED: see `reasoning` above for the empty-content salvage.
+                        // Raw fragments, not `reasoning_text()` — that helper trims each delta, which
+                        // would eat the spaces between streamed words. `.or()` reads whichever spelling
+                        // arrived; a gateway that mirrors both carries the same text, not more of it.
                         // (Clear the spinner: the model IS producing, just not user-facing text yet.)
-                        if choice.delta.reasoning_text().is_some() {
-                            spin.take();
+                        if let Some(raw) = choice
+                            .delta
+                            .reasoning_content
+                            .as_deref()
+                            .or(choice.delta.reasoning.as_deref())
+                        {
+                            if !raw.trim().is_empty() {
+                                spin.take();
+                            }
+                            reasoning.push_str(raw);
                         }
                         if let Some(content) = &choice.delta.content {
                             spin.take(); // stop+clear the spinner before the first token prints
@@ -1647,30 +1769,81 @@ pub async fn stream_chat_with_tools_eager(
                 .map(|e| e.to_string())
                 .unwrap_or_else(|| "stream closed with no output".to_string());
             stream_retry_note(&why, blank_attempt, STREAM_BLANK_RETRIES, delay);
-            // Detach any eager handles from the abandoned attempt. They are read-only by policy (the
-            // eager starter refuses destructive/unsafe calls), so dropping them is safe.
-            drop(eager_by_slot);
+            // Abort any eager handles from the abandoned attempt. They are read-only by policy (the
+            // eager starter refuses destructive/unsafe calls), so cutting them short is safe — and
+            // aborting rather than detaching means they stop billing/working for a turn that no
+            // longer exists. (A handle backed by `spawn_blocking` finishes its current body; abort
+            // still prevents anything after it.)
+            for h in eager_by_slot.into_values() {
+                h.abort();
+            }
             tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
             continue;
         }
 
-        // The display is now clean (fence closed, partial line flushed) — surface any transport error
-        // that interrupted the stream. The partial `full` / tool-calls are intentionally discarded: a
-        // truncated tool-call's arguments JSON is unparseable, so feeding it back would be worse than a
-        // clean turn failure the caller can retry.
+        // Map eager handles from accumulator SLOT to final POSITION (what the executor stitches by).
+        // COMPLETE calls only: `finish_indexed` drops any call whose streamed arguments never closed,
+        // so everything here is executable regardless of how the stream ended.
+        let indexed = acc.finish_indexed();
+
+        // The display is now clean (fence closed, partial line flushed) — deal with a transport error
+        // that interrupted the stream. Two cases:
+        //  * At least one COMPLETE tool call arrived → SALVAGE the turn: return it as a tools turn.
+        //    The executor runs the calls and the next request continues naturally — strictly better
+        //    than discarding finished work and re-paying the whole generation. The partial text (if
+        //    any) rides along: it is already on screen, and history matching the display beats a
+        //    retry that re-prints it.
+        //  * No complete call → fail the turn. Partial TEXT alone is not returned as success: that
+        //    would present a cut-off answer as a finished one.
         if let Some(e) = stream_err {
-            return Err(e);
+            if indexed.is_empty() {
+                if produced {
+                    // The loop above will likely retry this turn; the partial text stays on screen
+                    // (retained blocks are append-only), so say why the answer may appear twice.
+                    let note = "⚠ stream dropped mid-answer — on retry the text above may repeat \
+                                on screen (the saved transcript stays clean)";
+                    if crate::ui::tui::active() {
+                        crate::ui::tui::emit_line(&crate::ui::theme::faint(note).to_string());
+                    } else {
+                        eprintln!("{note}");
+                    }
+                }
+                for h in eager_by_slot.into_values() {
+                    h.abort();
+                }
+                return Err(e);
+            }
+            let note = format!(
+                "⟳ stream dropped mid-turn — continuing with {} completed tool call(s)",
+                indexed.len()
+            );
+            if crate::ui::tui::active() {
+                crate::ui::tui::emit_line(&crate::ui::theme::faint(note).to_string());
+            } else {
+                eprintln!("{note}");
+            }
+            if finish_reason.is_none() {
+                finish_reason = Some("tool_calls".to_string());
+            }
         }
 
-        // Map eager handles from accumulator SLOT to final POSITION (what the executor stitches by).
-        let indexed = acc.finish_indexed();
         let eager: Vec<(usize, tokio::task::JoinHandle<String>)> = indexed
             .iter()
             .enumerate()
             .filter_map(|(pos, (slot, _))| eager_by_slot.remove(slot).map(|h| (pos, h)))
             .collect();
+        // Streaming twin of `resolve_content` (non-streaming): a model that answered ONLY in the
+        // reasoning channel produced an answer, not an empty turn. Same narrow gate — no real
+        // content, no tool calls — so chain-of-thought is never APPENDED to a real answer.
+        let content = if !full.is_empty() {
+            Some(full)
+        } else if indexed.is_empty() && !reasoning.trim().is_empty() {
+            Some(reasoning.trim().to_string())
+        } else {
+            None
+        };
         return Ok(ChatTurn {
-            content: if full.is_empty() { None } else { Some(full) },
+            content,
             tool_calls: indexed.into_iter().map(|(_, tc)| tc).collect(),
             finish_reason,
             usage: final_usage,
@@ -1985,10 +2158,22 @@ mod tests {
                 "{code} must be Permanent"
             );
         }
+        // 402/422/451 were the substring-matcher's blind spot: unfixable client errors that fell
+        // through to Transient and burned every retry the budget had (forever, under /goal).
+        for code in ["HTTP 402", "HTTP 405", "HTTP 422", "HTTP 451"] {
+            let e = anyhow::anyhow!("upstream returned {code} Nope: denied");
+            assert_eq!(
+                classify_api_error(&e),
+                ApiErrorKind::Permanent,
+                "{code} must be Permanent"
+            );
+        }
         // Everything else leans Transient (goal mode's survival bias).
         for msg in [
             "upstream returned HTTP 429 Too Many Requests: slow down",
+            "upstream returned HTTP 408 Request Timeout: too slow",
             "upstream returned HTTP 503 Service Unavailable: try later",
+            "upstream returned HTTP 529 Overloaded: busy",
             "request failed after retries",
             "SSE stream error: connection reset",
             "health probe request failed",
@@ -2000,6 +2185,30 @@ mod tests {
                 "{msg} must be Transient"
             );
         }
+    }
+
+    #[test]
+    fn classify_api_error_names_context_overflow() {
+        // Overflow wears a permanent status (400/413) but has its own recovery — the loop shrinks
+        // the transcript and retries once. Both routes must classify as ContextOverflow: the
+        // status route (413) and the body route (a 400 whose message says the context overflowed).
+        for msg in [
+            "upstream returned HTTP 413 Payload Too Large: request entity too large",
+            "upstream returned HTTP 400 Bad Request: {\"error\":{\"code\":\"context_length_exceeded\"}}",
+            "upstream returned HTTP 400 Bad Request: this model's maximum context length is 128000",
+            "upstream returned HTTP 400 Bad Request: prompt is too long: 210000 tokens",
+        ] {
+            let e = anyhow::anyhow!(msg);
+            assert_eq!(
+                classify_api_error(&e),
+                ApiErrorKind::ContextOverflow,
+                "{msg} must be ContextOverflow"
+            );
+        }
+        // …while an unrelated 400 stays Permanent: a false positive here would shrink a healthy
+        // transcript instead of surfacing a real config error.
+        let e = anyhow::anyhow!("upstream returned HTTP 400 Bad Request: unknown parameter foo");
+        assert_eq!(classify_api_error(&e), ApiErrorKind::Permanent);
     }
 
     #[test]

--- a/src/llm/responses_codex.rs
+++ b/src/llm/responses_codex.rs
@@ -259,8 +259,12 @@ pub async fn stream_turn(
     let mut access_account = oauth_codex::bearer_token().await?;
     let body = build_request_body(model, messages, tools, session_id, None);
 
-    // Up to 2 auth attempts (refresh on 401) and a few overload retries.
+    // Up to 2 auth attempts (refresh on 401) and a few transient retries. This path used to be a
+    // second-class transport (raw `.send()`, immediate bail on 429/5xx, linear un-jittered
+    // sleeps); it now mirrors `send_with_retry`'s discipline with the same jittered backoff.
     let mut overload_attempt = 0u32;
+    let mut transient_attempt = 0u32;
+    const TRANSIENT_RETRIES: u32 = 3;
     loop {
         let (access, account) = &access_account;
         let headers = build_headers(access, account.as_deref(), session_id);
@@ -293,13 +297,30 @@ pub async fn stream_turn(
         }
         if status.as_u16() == 429 {
             let text = resp.text().await.unwrap_or_default();
+            // A spent QUOTA is permanent for this window — retrying burns nothing but time.
             if let Some(msg) = parse_usage_limit(&text) {
                 bail!("{msg}");
+            }
+            // Plain rate limiting is transient: back off and retry like every other gateway.
+            if transient_attempt < TRANSIENT_RETRIES {
+                let delay = crate::llm::client::backoff_ms(transient_attempt, 500, 15_000);
+                transient_attempt += 1;
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                continue;
             }
             bail!("Codex rate limited (HTTP 429): {}", truncate(&text, 300));
         }
         if !status.is_success() {
+            let code = status.as_u16();
             let text = resp.text().await.unwrap_or_default();
+            if crate::llm::client::is_retryable_status(code)
+                && transient_attempt < TRANSIENT_RETRIES
+            {
+                let delay = crate::llm::client::backoff_ms(transient_attempt, 500, 15_000);
+                transient_attempt += 1;
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                continue;
+            }
             bail!("Codex HTTP {status}: {}", truncate(&text, 500));
         }
 
@@ -317,14 +338,18 @@ pub async fn stream_turn(
                 bail!("Codex upstream overloaded — retries exhausted");
             }
             overload_attempt += 1;
-            tokio::time::sleep(Duration::from_secs(
-                2u64.saturating_mul(overload_attempt as u64),
-            ))
-            .await;
+            let delay = crate::llm::client::backoff_ms(overload_attempt - 1, 1_000, 15_000);
+            tokio::time::sleep(Duration::from_millis(delay)).await;
             continue;
         }
 
-        return parse_sse_to_chat_turn(&text);
+        let turn = parse_sse_to_chat_turn(&text)?;
+        // Codex turns used to be invisible to `/cost` and the cache HUD — the one chat path that
+        // never recorded usage. Same meter as the OpenAI-dialect paths.
+        if let Some(u) = &turn.usage {
+            crate::llm::client::cost_meter().record(u);
+        }
+        return Ok(turn);
     }
 }
 
@@ -489,7 +514,12 @@ pub fn parse_sse_to_chat_turn(sse: &str) -> Result<ChatTurn> {
     }
 
     if let Some(e) = err_msg {
-        if text_out.is_empty() && tools.is_empty() {
+        // A failure event fails the turn unless the stream ALSO completed normally afterwards
+        // (`response.completed` sets `finish`). The old gate only bailed when text AND tools were
+        // both empty, so a stream cut down mid-answer returned its partial text as a clean
+        // `finish_reason: "stop"` turn — the caller could not tell a finished answer from a
+        // truncated one. An error the turn recovered from (completed anyway) is still fine.
+        if finish.is_none() {
             bail!("Codex error: {e}");
         }
     }
@@ -590,7 +620,15 @@ fn parse_usage(u: &Value) -> Option<Usage> {
         .or_else(|| u.get("completion_tokens"))
         .and_then(|x| x.as_u64());
     usage.total_tokens = u.get("total_tokens").and_then(|x| x.as_u64());
-    usage.cache_read_input_tokens = u.get("cache_read_input_tokens").and_then(|x| x.as_u64());
+    // The Responses dialect reports cached prompt tokens under `input_tokens_details`; keep the
+    // flat spelling too for gateways that mirror the Anthropic shape.
+    usage.cache_read_input_tokens = u
+        .get("cache_read_input_tokens")
+        .and_then(|x| x.as_u64())
+        .or_else(|| {
+            u.pointer("/input_tokens_details/cached_tokens")
+                .and_then(|x| x.as_u64())
+        });
     Some(usage)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,12 @@ async fn main() -> Result<()> {
                 println!("{}", crate::agent::mcp::summary());
                 Ok(())
             }
+            // On a blocking thread on purpose: a `task` dispatch bridges to async with
+            // `block_in_place`, and `spawn_blocking` is the context that bridge is verified against
+            // (same as the tool executor's parallel path).
+            McpCmd::Serve { yes } => {
+                tokio::task::spawn_blocking(move || crate::agent::mcp_serve::run(yes)).await?
+            }
             McpCmd::Untrust => {
                 crate::agent::mcp::untrust_project()?;
                 println!(

--- a/src/repl/background.rs
+++ b/src/repl/background.rs
@@ -48,6 +48,9 @@ pub(crate) fn classify_health_probe(
         Err(e) => match client::classify_api_error(&e) {
             client::ApiErrorKind::Permanent => tui::HealthKind::Down,
             client::ApiErrorKind::Transient => tui::HealthKind::Unstable,
+            // A probe request can't overflow a context window, but the arm must exist; a 413
+            // from a health probe says the endpoint is reachable and objecting — yellow, not red.
+            client::ApiErrorKind::ContextOverflow => tui::HealthKind::Unstable,
         },
     }
 }

--- a/src/repl/turn.rs
+++ b/src/repl/turn.rs
@@ -389,6 +389,12 @@ pub(crate) fn show_clarify(display: &str) {
             tui::emit_line(o);
         }
         tui::emit_line(&hint);
+        // Suggested options → raise the picker over the input box (↑↓/click + Enter submits the
+        // choice as the next user message). The numbered list above STAYS in the transcript: the
+        // menu is dismissible (Esc / just start typing), and the options must survive its dismissal
+        // for the free-text path. No-ops when there are no options to offer.
+        let (q, options) = crate::agent::clarify::parse_display(display);
+        tui::question_menu_open(q, &options);
     } else {
         println!("{head}");
         for o in &opts {

--- a/src/tests/main_suite.rs
+++ b/src/tests/main_suite.rs
@@ -129,6 +129,40 @@ fn agent_effort_takes_the_ladder_and_nothing_else() {
     assert!(Cli::try_parse_from(["aizen", "agent", "--effort", "mediumish", "việc"]).is_err());
 }
 
+/// `--image` takes a value, repeats, and must never be mistaken for the task.
+///
+/// The task is positional, so every flag on this subcommand is one bad definition away from
+/// swallowing it. A front-end sends `--image <path> <task>`, and if the flag were ever made
+/// optional-valued clap would read the task as the path: the run would then fail with "not a
+/// PNG/JPEG/GIF/WebP image" naming the user's own sentence, which is a mystifying way to say
+/// nothing was attached. Repeatable because one screenshot is the common case and two is not rare.
+#[test]
+fn agent_image_is_repeatable_and_never_eats_the_task() {
+    let cli = Cli::try_parse_from([
+        "aizen",
+        "agent",
+        "--image",
+        "a.png",
+        "--image",
+        "b.jpg",
+        "cái nút này sai chỗ nào",
+    ])
+    .expect("parse");
+    let Some(Commands::Agent(args)) = cli.command else {
+        panic!("expected the agent subcommand");
+    };
+    assert_eq!(args.image, vec!["a.png".to_string(), "b.jpg".to_string()]);
+    assert_eq!(args.task, "cái nút này sai chỗ nào");
+
+    // Omitted is the old shape exactly: no parts array, no image field, a request byte-identical
+    // to one from a core that never had this flag.
+    let plain = Cli::try_parse_from(["aizen", "agent", "chạy test"]).expect("parse");
+    assert!(matches!(plain.command, Some(Commands::Agent(a)) if a.image.is_empty()));
+
+    // A value is required, so the flag can never stand alone and leave the task unaccounted for.
+    assert!(Cli::try_parse_from(["aizen", "agent", "--image"]).is_err());
+}
+
 /// `memory list current` and `memory list --scope current` must mean the same thing.
 ///
 /// The REPL has always taken the scope positionally (`/memory list current`), so that is the form

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -689,6 +689,15 @@ struct Render {
     text_overlay_scroll: usize,
     text_overlay_title: String,
     text_overlay_lines: Vec<String>,
+    /// Destructive-op approval menu (the Claude-style picker over the y/n/a gate). Outranks every
+    /// other overlay: it only exists while the agent loop is BLOCKED waiting on the answer.
+    approval_menu_active: bool,
+    approval_menu_sel: usize,
+    /// `clarify` answer menu: the question's suggested options plus a trailing "type my own" row.
+    question_menu_active: bool,
+    question_menu_sel: usize,
+    question_menu_question: String,
+    question_menu_options: Vec<String>,
     /// Chat/slash submissions waiting while a turn runs (shown in the prompt placeholder).
     queued_count: usize,
 }
@@ -715,6 +724,12 @@ fn render() -> &'static Mutex<Render> {
             text_overlay_scroll: 0,
             text_overlay_title: String::new(),
             text_overlay_lines: Vec::new(),
+            approval_menu_active: false,
+            approval_menu_sel: 0,
+            question_menu_active: false,
+            question_menu_sel: 0,
+            question_menu_question: String::new(),
+            question_menu_options: Vec::new(),
             queued_count: 0,
         })
     })
@@ -864,10 +879,41 @@ pub fn reset_session_allow() {
     SESSION_ALLOW.store(false, Ordering::Relaxed);
 }
 
+/// The approval menu's rows, in the order painted. Index ↔ decision is pinned by
+/// [`approval_menu_decision`]; keep the two in lock-step.
+const APPROVAL_MENU_ROWS: [&str; 4] = [
+    "Yes — run this action",
+    "Yes — allow all destructive actions this session",
+    "No — skip this action (the agent continues)",
+    "No — stop the turn and tell it what to do",
+];
+
+/// Map an approval-menu row to `(answer_char, also_cancel_turn)`. The char is what the blocked
+/// [`ask_approval`] gate receives on its channel ('y' / 'a' / 'n'); `true` in the second slot means
+/// the row ALSO stops the turn (the Esc semantic: deny this call and unwind the loop, so the user
+/// can say what to do instead of watching the agent barrel on).
+fn approval_menu_decision(sel: usize) -> (char, bool) {
+    match sel {
+        0 => ('y', false),
+        1 => ('a', false),
+        2 => ('n', false),
+        _ => ('n', true),
+    }
+}
+
+/// Whether the approval MENU overlay is up (retained surface only — the y/n/a keys work regardless).
+fn approval_menu_showing() -> bool {
+    render().lock().unwrap().approval_menu_active
+}
+
 /// Block until the user answers an in-TUI approval prompt; `true` = allow. Routed through the
 /// keyboard thread so it composes with the pinned box instead of fighting it for stdin. MUST be
 /// called from the SERIAL tool path on a tokio worker (the caller wraps it in `block_in_place`),
 /// never from the parallel scoped-thread batch. Safe-denies if the TUI isn't active.
+///
+/// Under the retained backend this also raises the approval MENU overlay (arrow keys / Enter /
+/// mouse click pick a row); the y/n/a accelerator keys keep working either way, so the menu is a
+/// presentation layer over the same one-char channel, not a second decision path.
 pub fn ask_approval(prompt_line: &str) -> bool {
     if session_allow_all() {
         return true;
@@ -882,8 +928,25 @@ pub fn ask_approval(prompt_line: &str) -> bool {
     let (tx, rx) = stdmpsc::channel::<char>();
     *approval_slot().lock().unwrap_or_else(|e| e.into_inner()) = Some(tx);
     APPROVAL_PENDING.store(true, Ordering::Relaxed);
+    let menu = retained_running();
+    if menu {
+        {
+            let mut r = render().lock().unwrap();
+            r.approval_menu_active = true;
+            r.approval_menu_sel = 0;
+        }
+        repaint_force();
+    }
     let ans = rx.recv().unwrap_or('n'); // a dropped sender (shouldn't happen) → safe-deny
     APPROVAL_PENDING.store(false, Ordering::Relaxed);
+    if menu {
+        {
+            let mut r = render().lock().unwrap();
+            r.approval_menu_active = false;
+            r.approval_menu_sel = 0;
+        }
+        repaint_force();
+    }
     match ans {
         'a' => {
             SESSION_ALLOW.store(true, Ordering::Relaxed);
@@ -892,6 +955,232 @@ pub fn ask_approval(prompt_line: &str) -> bool {
         'y' => true,
         _ => false,
     }
+}
+
+// ── clarify question menu ─────────────────────────────────────────────────────
+// When a `clarify` call pauses the turn WITH suggested options, the sticky REPL raises a picker over
+// the input box (Claude-style): ↑↓/click choose an option, Enter submits it as the next user
+// message through the SAME submission channel a typed answer would use. Esc — or just typing —
+// dismisses the menu and falls back to free-text, so the picker is a shortcut, never a cage.
+
+/// The trailing non-option row: dismisses the menu and hands focus back to the draft.
+const QUESTION_MENU_FREEFORM_ROW: &str = "✎ type my own answer…";
+
+/// Whether the clarify answer menu is up (input thread routes ↑↓/Enter/digits to it).
+pub fn question_menu_active() -> bool {
+    render().lock().unwrap().question_menu_active
+}
+
+/// Raise the clarify answer menu. No-ops outside the sticky TUI or with no options to offer — the
+/// free-text path (type your answer, press Enter) is always available and always correct.
+pub fn question_menu_open(question: &str, options: &[String]) {
+    if !active() || options.is_empty() {
+        return;
+    }
+    question_menu_set(question, options);
+    repaint_force();
+}
+
+/// State half of [`question_menu_open`], separated so tests can drive the menu without a live TUI.
+fn question_menu_set(question: &str, options: &[String]) {
+    let mut r = render().lock().unwrap();
+    r.question_menu_active = true;
+    r.question_menu_sel = 0;
+    r.question_menu_question = question.to_string();
+    r.question_menu_options = options.to_vec();
+}
+
+/// Dismiss the clarify answer menu (picked, Esc'd, or superseded by typing).
+fn question_menu_close() {
+    {
+        let mut r = render().lock().unwrap();
+        r.question_menu_active = false;
+        r.question_menu_sel = 0;
+        r.question_menu_question.clear();
+        r.question_menu_options.clear();
+    }
+    repaint_force();
+}
+
+/// Resolve a pick on the clarify menu: option rows submit the option text as the next user message
+/// (identical to typing it and pressing Enter); the trailing free-form row just dismisses.
+fn question_menu_pick(idx: usize, sub_tx: &UnboundedSender<Submission>) {
+    let text = {
+        let r = render().lock().unwrap();
+        r.question_menu_options.get(idx).cloned()
+    };
+    question_menu_close();
+    if let Some(text) = text {
+        if sub_tx.send(Submission::Chat(text, Vec::new())).is_ok() {
+            note_submission_enqueued();
+        }
+    }
+}
+
+/// Handle one key while the clarify menu is open. Returns `true` if the key was consumed.
+///
+/// Deliberately porous, unlike the other menus: printable chars and Backspace dismiss the menu and
+/// fall THROUGH to draft editing (`false`), because the menu offers suggestions — it must never
+/// stand between the user and typing their real answer. Enter with a non-empty draft also falls
+/// through, so an answer typed or pasted while the menu was up submits normally.
+fn question_menu_handle_key(key: &Key, sub_tx: &UnboundedSender<Submission>) -> bool {
+    if !question_menu_active() {
+        return false;
+    }
+    let (rows, sel) = {
+        let r = render().lock().unwrap();
+        (r.question_menu_options.len() + 1, r.question_menu_sel)
+    };
+    match key {
+        Key::ArrowUp => {
+            if sel > 0 {
+                render().lock().unwrap().question_menu_sel = sel - 1;
+                repaint();
+            }
+            true
+        }
+        Key::ArrowDown => {
+            if sel + 1 < rows {
+                render().lock().unwrap().question_menu_sel = sel + 1;
+                repaint();
+            }
+            true
+        }
+        // Digits highlight (not submit): a stray key must not fire an answer at the agent.
+        Key::Char(c @ '1'..='9') => {
+            let idx = (*c as usize) - ('1' as usize);
+            if idx < rows.saturating_sub(1) {
+                render().lock().unwrap().question_menu_sel = idx;
+                repaint();
+                true
+            } else {
+                // Not an option number → the user is typing an answer that starts with a digit.
+                question_menu_close();
+                false
+            }
+        }
+        Key::Enter => {
+            if !render().lock().unwrap().draft.is_empty() {
+                // A typed/pasted answer outranks the highlight — submit it via the normal path.
+                question_menu_close();
+                return false;
+            }
+            if sel + 1 == rows {
+                question_menu_close(); // "type my own" → back to the draft
+            } else {
+                question_menu_pick(sel, sub_tx);
+            }
+            true
+        }
+        Key::Escape => {
+            question_menu_close();
+            true
+        }
+        // Ctrl-C keeps its global meaning (copy/quit); don't trap the user in the menu.
+        Key::CtrlC | Key::Char('\u{3}') | Key::Char('\u{4}') => {
+            question_menu_close();
+            false
+        }
+        Key::Backspace | Key::Del => {
+            question_menu_close();
+            false
+        }
+        Key::Char(c) if !c.is_control() => {
+            question_menu_close();
+            false
+        }
+        _ => true, // swallow the rest so navigation keys don't scroll/edit under the menu
+    }
+}
+
+/// Route a left-click that landed on row `idx` of the open overlay MENU (per the render thread's
+/// published geometry) to whichever menu is up, in the same priority order the snapshot paints
+/// them. Returns `true` when the click was consumed as a pick/selection.
+///
+/// A click is a full pick (select + confirm) for the dialog menus — approval, clarify, model,
+/// sessions — because their rows are buttons. For the typing-flow overlays (`@` files, slash
+/// palette) it only moves the highlight: their Enter/Tab semantics are entangled with the draft,
+/// and a click that ran a command the user was still reading would be worse than one more keypress.
+fn overlay_menu_click(
+    idx: usize,
+    sub_tx: &UnboundedSender<Submission>,
+    cancel_tx: &UnboundedSender<()>,
+) -> bool {
+    if APPROVAL_PENDING.load(Ordering::Relaxed) && approval_menu_showing() {
+        if idx >= APPROVAL_MENU_ROWS.len() {
+            return true; // dead zone inside the panel — swallow, never start a selection under it
+        }
+        {
+            let mut r = render().lock().unwrap();
+            r.approval_menu_sel = idx;
+        }
+        let (c, cancel) = approval_menu_decision(idx);
+        if let Some(tx) = approval_slot()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
+            let _ = tx.send(c);
+        }
+        if cancel {
+            request_cancel();
+            let _ = cancel_tx.send(());
+            crate::core::steer::clear();
+        }
+        return true;
+    }
+    if question_menu_active() {
+        let options = render().lock().unwrap().question_menu_options.len();
+        if idx < options {
+            question_menu_pick(idx, sub_tx);
+        } else {
+            question_menu_close(); // the "type my own" row (or a stale row) → back to the draft
+        }
+        return true;
+    }
+    if model_menu_active() {
+        let pick = {
+            let mut slot = model_menu_slot().lock().unwrap();
+            let pick = slot.rows.get(idx).map(|r| r.id.clone());
+            if pick.is_some() {
+                slot.sel = idx;
+            }
+            pick
+        };
+        if pick.is_some() {
+            model_menu_finish(pick);
+        }
+        return true;
+    }
+    if sessions_menu_active() {
+        let valid = {
+            let mut slot = sessions_menu_slot().lock().unwrap();
+            let valid = idx < slot.rows.len();
+            if valid {
+                slot.sel = idx;
+            }
+            valid
+        };
+        if valid {
+            sessions_menu_finish(Some(SessionsMenuChoice::Pick(idx)));
+        }
+        return true;
+    }
+    // Draft-derived overlays: move the highlight only (Enter/Tab keep their meaning).
+    let mut r = render().lock().unwrap();
+    if !at_matches(&r.draft).is_empty() {
+        r.at_sel = idx;
+        drop(r);
+        repaint();
+        return true;
+    }
+    if !slash_matches(&r.draft).is_empty() {
+        r.palette_sel = idx;
+        drop(r);
+        repaint();
+        return true;
+    }
+    false
 }
 
 /// The width (columns) the frame is drawn at — the canonical wrap width for streamed output so the
@@ -1400,7 +1689,25 @@ fn repaint() {
 /// still owns editing semantics; only drawing moved to the render thread.
 fn retained_input_snapshot() -> retained::InputSnapshot {
     let r = render().lock().unwrap();
-    let overlay = if r.model_menu_active {
+    let overlay = if r.approval_menu_active {
+        // Highest priority: the agent loop is blocked on this answer, and the full command line is
+        // already in the transcript right above — the panel only has to carry the choices.
+        Some(retained::OverlaySnapshot {
+            title: "approve?".to_string(),
+            lines: APPROVAL_MENU_ROWS.iter().map(|s| s.to_string()).collect(),
+            selected: Some(r.approval_menu_sel.min(APPROVAL_MENU_ROWS.len() - 1)),
+            hint: "↑↓/click pick · Enter confirm · y/a/n direct · Esc stop".to_string(),
+        })
+    } else if r.question_menu_active {
+        let mut lines: Vec<String> = r.question_menu_options.clone();
+        lines.push(QUESTION_MENU_FREEFORM_ROW.to_string());
+        Some(retained::OverlaySnapshot {
+            title: format!("❓ {}", r.question_menu_question),
+            lines,
+            selected: Some(r.question_menu_sel),
+            hint: "↑↓/click pick · Enter answer · Esc/type your own".to_string(),
+        })
+    } else if r.model_menu_active {
         Some(retained::OverlaySnapshot {
             title: "model".to_string(),
             lines: r
@@ -2188,6 +2495,7 @@ fn input_loop(
                     && crate::ui::splash::logo_is_sixel()
                     && !WORKING.load(Ordering::Relaxed)
                     && !APPROVAL_PENDING.load(Ordering::Relaxed)
+                    && !question_menu_active()
                     && !model_menu_active()
                     && !sessions_menu_active()
                     && !text_overlay_active()
@@ -2346,6 +2654,16 @@ fn input_loop(
                         }
                         continue;
                     }
+                    // A left-click on an open menu overlay's rows is a pick, and it must win over
+                    // the transcript handler below — otherwise the click would start a text
+                    // selection UNDER the panel the user is aiming at.
+                    if matches!(me.kind, MouseEventKind::Down(MouseButton::Left)) {
+                        if let Some(idx) = retained::overlay_menu_hit(me.column, me.row) {
+                            if overlay_menu_click(idx, &sub_tx, &cancel_tx) {
+                                continue;
+                            }
+                        }
+                    }
                     handle_retained_mouse(
                         me.kind,
                         me.column,
@@ -2429,6 +2747,42 @@ fn input_loop(
                 crate::core::steer::clear();
                 continue;
             }
+            // Menu navigation (retained surface): ↑↓ move the highlight, Enter confirms the
+            // highlighted row — but ONLY over an empty draft, so Enter on a message typed while the
+            // gate is up still queues it exactly as before the menu existed.
+            if approval_menu_showing() {
+                match key {
+                    Key::ArrowUp | Key::ArrowDown => {
+                        let mut r = render().lock().unwrap();
+                        let last = APPROVAL_MENU_ROWS.len() - 1;
+                        r.approval_menu_sel = match key {
+                            Key::ArrowUp => r.approval_menu_sel.saturating_sub(1),
+                            _ => (r.approval_menu_sel + 1).min(last),
+                        };
+                        drop(r);
+                        repaint();
+                        continue;
+                    }
+                    Key::Enter if render().lock().unwrap().draft.is_empty() => {
+                        let sel = render().lock().unwrap().approval_menu_sel;
+                        let (c, cancel) = approval_menu_decision(sel);
+                        if let Some(tx) = approval_slot()
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .take()
+                        {
+                            let _ = tx.send(c);
+                        }
+                        if cancel {
+                            request_cancel();
+                            let _ = cancel_tx.send(());
+                            crate::core::steer::clear();
+                        }
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
             let decided = match key {
                 Key::Char('y') | Key::Char('Y') => Some('y'),
                 Key::Char('a') | Key::Char('A') => Some('a'),
@@ -2445,7 +2799,11 @@ fn input_loop(
                 }
                 continue;
             }
-            // y/n/a only — other keys still edit the draft / queue messages (Claude-style).
+            // y/n/a and the menu keys only — other keys still edit the draft / queue messages
+            // (Claude-style).
+        }
+        if question_menu_handle_key(&key, &sub_tx) {
+            continue;
         }
         if model_menu_handle_key(&key) {
             continue;
@@ -4059,6 +4417,109 @@ mod tests {
         );
         reset_session_allow();
         assert!(!session_allow_all(), "reset clears it");
+    }
+
+    /// Serializes the tests below that drive the process-global question/approval menu state —
+    /// cargo runs tests in parallel threads, and two tests opening/closing the same menu would
+    /// interleave.
+    static MENU_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn approval_menu_rows_and_decisions_stay_in_lockstep() {
+        // Every painted row must map to a decision; the mapping is what a click/Enter fires.
+        assert_eq!(APPROVAL_MENU_ROWS.len(), 4);
+        assert_eq!(approval_menu_decision(0), ('y', false), "run once");
+        assert_eq!(approval_menu_decision(1), ('a', false), "session allow");
+        assert_eq!(approval_menu_decision(2), ('n', false), "deny, keep going");
+        assert_eq!(
+            approval_menu_decision(3),
+            ('n', true),
+            "deny AND stop the turn — the Esc semantic as a row"
+        );
+        // Labels and decisions must agree on which half is which: the two allow rows lead.
+        assert!(
+            APPROVAL_MENU_ROWS[0].starts_with("Yes") && APPROVAL_MENU_ROWS[1].starts_with("Yes")
+        );
+        assert!(APPROVAL_MENU_ROWS[2].starts_with("No") && APPROVAL_MENU_ROWS[3].starts_with("No"));
+    }
+
+    #[test]
+    fn question_menu_picks_submit_and_typing_falls_through() {
+        let _g = MENU_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (tx, mut rx) = mpsc::unbounded_channel::<Submission>();
+        question_menu_set(
+            "Which file?",
+            &["src/a.rs".to_string(), "src/b.rs".to_string()],
+        );
+        assert!(question_menu_active());
+        {
+            // Enter must read an empty draft to mean "confirm the highlight".
+            let mut r = render().lock().unwrap();
+            r.draft.clear();
+            r.cursor = 0;
+        }
+        // ↓ moves the highlight, Enter submits the highlighted option as a normal chat message.
+        assert!(question_menu_handle_key(&Key::ArrowDown, &tx));
+        assert!(question_menu_handle_key(&Key::Enter, &tx));
+        assert!(!question_menu_active(), "picking closes the menu");
+        match rx.try_recv() {
+            Ok(Submission::Chat(text, imgs)) => {
+                assert_eq!(text, "src/b.rs");
+                assert!(imgs.is_empty());
+            }
+            other => panic!("expected the picked option as a Chat submission, got {other:?}"),
+        }
+        // Typing dismisses the menu and the key falls through to the draft (`false`).
+        question_menu_set("Q?", &["A".to_string()]);
+        assert!(!question_menu_handle_key(&Key::Char('x'), &tx));
+        assert!(!question_menu_active(), "typing dismisses");
+        assert!(rx.try_recv().is_err(), "dismissal submits nothing");
+        // Esc dismisses too, but is consumed (it must never fall through to the Quit arm).
+        question_menu_set("Q?", &["A".to_string()]);
+        assert!(question_menu_handle_key(&Key::Escape, &tx));
+        assert!(!question_menu_active());
+        // The trailing free-form row dismisses without submitting.
+        question_menu_set("Q?", &["A".to_string()]);
+        assert!(question_menu_handle_key(&Key::ArrowDown, &tx)); // onto "type my own"
+        assert!(question_menu_handle_key(&Key::Enter, &tx));
+        assert!(!question_menu_active());
+        assert!(rx.try_recv().is_err(), "free-form row submits nothing");
+    }
+
+    #[test]
+    fn menu_overlays_outrank_the_draft_palettes_in_the_snapshot() {
+        let _g = MENU_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Approval outranks question outranks the rest — the agent is BLOCKED on approval, so
+        // nothing may paint over it.
+        {
+            let mut r = render().lock().unwrap();
+            r.approval_menu_active = true;
+            r.approval_menu_sel = 2;
+            r.question_menu_active = true;
+            r.question_menu_options = vec!["A".to_string()];
+        }
+        let snap = retained_input_snapshot();
+        let overlay = snap.overlay.expect("approval menu must paint an overlay");
+        assert_eq!(overlay.title, "approve?");
+        assert_eq!(overlay.lines.len(), APPROVAL_MENU_ROWS.len());
+        assert_eq!(overlay.selected, Some(2));
+        {
+            let mut r = render().lock().unwrap();
+            r.approval_menu_active = false;
+            r.approval_menu_sel = 0;
+        }
+        let snap = retained_input_snapshot();
+        let overlay = snap
+            .overlay
+            .expect("question menu paints once approval is gone");
+        assert!(overlay.title.contains('❓'));
+        assert_eq!(
+            overlay.lines.last().map(String::as_str),
+            Some(QUESTION_MENU_FREEFORM_ROW),
+            "the free-form escape hatch is always the last row"
+        );
+        question_menu_close();
+        assert!(retained_input_snapshot().overlay.is_none() || !question_menu_active());
     }
 
     /// The Esc-responsiveness invariant, pinned end to end.

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -756,6 +756,51 @@ fn draft_selection() -> Option<(usize, usize)> {
     normalized_draft_sel(r.draft_sel, r.draft.len())
 }
 
+/// Move the draft caret one LOGICAL line up (`dir < 0`) or down, keeping its column. `false` when the
+/// draft has no line that way — the caller then falls through to history recall, which is what ↑/↓
+/// still mean on a one-line draft.
+///
+/// The composer paints a multi-line draft over several rows now, so ↑/↓ walking those rows is what
+/// the box looks like it should do. Without this the first ↑ inside a pasted block swaps the whole
+/// block out for the last message, which reads as losing it.
+fn move_draft_caret_line(dir: i32) -> bool {
+    let mut r = render().lock().unwrap();
+    if !r.draft.contains(&'\n') {
+        return false;
+    }
+    let cursor = r.cursor.min(r.draft.len());
+    let line_start = r.draft[..cursor]
+        .iter()
+        .rposition(|&c| c == '\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let col = cursor - line_start;
+    if dir < 0 {
+        if line_start == 0 {
+            return false; // already on the first line
+        }
+        let prev_start = r.draft[..line_start - 1]
+            .iter()
+            .rposition(|&c| c == '\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        // The column is clamped to the shorter line, as every editor does.
+        let prev_len = line_start - 1 - prev_start;
+        r.cursor = prev_start + col.min(prev_len);
+    } else {
+        let Some(rel) = r.draft[cursor..].iter().position(|&c| c == '\n') else {
+            return false; // already on the last line
+        };
+        let next_start = cursor + rel + 1;
+        let next_len = r.draft[next_start..]
+            .iter()
+            .position(|&c| c == '\n')
+            .unwrap_or(r.draft.len() - next_start);
+        r.cursor = next_start + col.min(next_len);
+    }
+    true
+}
+
 /// Drop the highlight without touching the text, repainting only if there was one to drop.
 fn clear_draft_selection() {
     let had = {
@@ -2127,9 +2172,9 @@ fn handle_retained_mouse(
 /// Mouse inside the input box: click to park the caret, drag to select, release to copy. Returns
 /// whether the event belonged to the box (the caller then leaves the transcript alone).
 ///
-/// This is the mouse half of editing the draft. Without it the caret could only be walked with ←/→,
-/// which on a draft longer than the box also dragged the whole line under a stationary cursor, and the
-/// only way to copy what you had typed was Ctrl-C taking ALL of it.
+/// This is the mouse half of editing the draft. Without it the caret could only be walked with ←/→
+/// through a draft that may now be wrapped over several rows, and the only way to copy what you had
+/// typed was Ctrl-C taking ALL of it.
 ///
 /// The box's highlight and the transcript's are deliberately exclusive — Ctrl-C has one meaning at a
 /// time, so starting one drops the other rather than leaving two highlights on screen competing to be
@@ -2163,10 +2208,10 @@ fn handle_input_box_mouse(
             let Some(anchor) = *dragging_draft else {
                 return false;
             };
-            // Column only, row ignored: the pointer leaves a one-row box constantly while selecting
-            // inside it, and a drag that stopped extending the moment it strayed a row would be
-            // unusable. Off either end of the text it clamps to the nearest edge.
-            if let Some(idx) = retained::input_hit_col(col) {
+            // The row is CLAMPED into the box rather than required to be on it: the pointer leaves
+            // the box constantly while selecting inside it, and a drag that stopped extending the
+            // moment it strayed would be unusable. Off either end it clamps to the nearest edge.
+            if let Some(idx) = retained::input_hit_drag(col, row) {
                 set_draft_caret(idx, Some((anchor, idx)));
             }
             true
@@ -3274,6 +3319,12 @@ fn input_loop(
                     repaint();
                     continue;
                 }
+                // A multi-line draft is painted over several rows, so ↑ walks those rows first and
+                // only means history once the caret is on the top one.
+                if move_draft_caret_line(-1) {
+                    repaint();
+                    continue;
+                }
                 // ↑ at the prompt recalls the previous message (readline-style), in BOTH backends.
                 // Transcript scrolling lives on PageUp/PageDown, so arrows are never stolen from recall.
                 if history.is_empty() {
@@ -3311,6 +3362,11 @@ fn input_loop(
                         r.palette_sel = r.palette_sel.saturating_sub(1);
                     }
                     drop(r);
+                    repaint();
+                    continue;
+                }
+                // Symmetric to ArrowUp: inside a multi-line draft ↓ walks down its rows first.
+                if move_draft_caret_line(1) {
                     repaint();
                     continue;
                 }

--- a/src/ui/tui/retained.rs
+++ b/src/ui/tui/retained.rs
@@ -53,7 +53,15 @@ pub(super) use self::widgets::*;
 #[cfg(test)]
 mod tests;
 
+/// Smallest footer that can be painted at all: HUD + rule + one text row + rule. Below this the
+/// composer is skipped entirely rather than drawn half-formed.
 const FOOTER_ROWS: u16 = 4;
+/// The footer's fixed furniture — the HUD strip and the two framing rules. Everything on top of
+/// this is composer text, which is why the footer's height is decided per frame rather than fixed.
+const FOOTER_CHROME_ROWS: u16 = 3;
+/// Ceiling on how tall the composer may grow. A long prompt wraps DOWN instead of scrolling
+/// sideways out of sight, but past this many rows a pasted wall of text would become the screen.
+const MAX_INPUT_TEXT_ROWS: u16 = 10;
 const CACHE_LIMIT: usize = 512;
 const BLOCK_LIMIT: usize = 2048;
 
@@ -317,14 +325,14 @@ struct AppState {
     /// How many chars of `work_caption` are revealed so far — advanced one per animation tick for the
     /// typewriter effect, clamped to the caption length.
     work_reveal: usize,
-    /// Draft index of the first char visible in the input box at the last draw.
+    /// First WRAPPED ROW of the draft visible in the composer at the last draw.
     ///
-    /// The window is STICKY: it only slides when the caret would otherwise fall off an edge. Re-deriving
-    /// it from the caret every frame (what this used to do) pinned the caret to the right edge, so on a
-    /// draft longer than the box every ←/→ scrolled the whole line under a stationary cursor instead of
-    /// moving the cursor through stationary text — and a click could never land where it was aimed,
-    /// because the text jumped as soon as the caret moved.
-    input_win_start: usize,
+    /// The box grows downward with the draft, so this is only non-zero once the draft is taller than
+    /// the box will go (`MAX_INPUT_TEXT_ROWS`, or what the terminal leaves after the transcript's
+    /// floor). The window is STICKY: it slides only when the caret would otherwise fall off an edge.
+    /// Re-deriving it from the caret every frame would pin the caret to the bottom row, so scrolling
+    /// back up through a long paste would snap away on the next repaint.
+    input_row_scroll: usize,
 }
 
 /// Absolute character selection over the flat list of wrapped transcript rows.
@@ -371,7 +379,7 @@ impl AppState {
             work_verb: String::new(),
             work_caption: String::new(),
             work_reveal: 0,
-            input_win_start: 0,
+            input_row_scroll: 0,
         }
     }
 

--- a/src/ui/tui/retained/geom.rs
+++ b/src/ui/tui/retained/geom.rs
@@ -93,22 +93,33 @@ pub(super) fn menu_hit_index(g: &OverlayMenuGeom, col: u16, row: u16) -> Option<
     (idx < g.rows).then_some(idx)
 }
 
-/// Where the input box's typed text landed on screen at the last draw, so the input thread can turn a
-/// mouse column into a caret position in the draft.
+/// Where the composer's typed text landed on screen at the last draw, so the input thread can turn a
+/// mouse position into a caret position in the draft.
 ///
 /// The draft is a `Vec<char>` but the screen is a grid of display CELLS, and the two do not line up:
-/// a CJK char or an emoji is two cells wide, a `\n` is painted as a one-cell `↵`, and only a window of
-/// a long draft is on screen at all. So the mapping is published as the column each visible char was
-/// actually painted at — measured by the code that painted it — rather than recomputed on the input
-/// thread from a width function that might disagree.
+/// a CJK char or an emoji is two cells wide, an embedded newline is painted as a blank cell, and a
+/// long draft is wrapped over several rows of which only a window may be on screen. So the mapping is
+/// published as the row and column each visible char was actually painted at — measured by the code
+/// that painted it — rather than recomputed on the input thread from a width function that might
+/// disagree.
 #[derive(Clone, Debug, Default)]
 pub(super) struct InputGeom {
-    /// Screen rect of the `❯ …` row. `width == 0` means nothing has been painted yet: no mapping.
-    pub(crate) row: Rect,
-    /// Draft index of the first char in the visible window.
+    /// Screen rect of the whole text area — every composer row between the framing rules.
+    /// `width == 0` means nothing has been painted yet: no mapping.
+    pub(crate) area: Rect,
+    /// One entry per painted row, top to bottom. Empty until the first frame is drawn.
+    pub(crate) rows: Vec<InputRowGeom>,
+}
+
+/// One painted composer row's mapping: where it is and which draft chars it shows.
+#[derive(Clone, Debug)]
+pub(super) struct InputRowGeom {
+    /// Absolute screen row.
+    pub(crate) y: u16,
+    /// Draft index of the first char on this row.
     pub(crate) start: usize,
-    /// Absolute start column of each visible char, plus one entry for the cell just past the last —
-    /// where a click beyond the end of the text parks the caret. Length is `visible chars + 1`.
+    /// Absolute start column of each char on the row, plus one entry for the cell just past the last —
+    /// where a click beyond the end of the row's text parks the caret. Length is `chars + 1`.
     pub(crate) cols: Vec<u16>,
 }
 
@@ -117,17 +128,29 @@ pub(super) fn input_geom_slot() -> &'static Mutex<InputGeom> {
     SLOT.get_or_init(|| Mutex::new(InputGeom::default()))
 }
 
-/// Draft index a click at column `col` points at, ignoring the row.
+/// Draft index a DRAG at (`col`, `row`) points at, with the row clamped into the box.
 ///
-/// Row-blind on purpose: it backs the DRAG half of a selection, where the pointer routinely leaves the
-/// one-row input box while the user is still selecting inside it. `input_hit` is the row-checked
-/// variant that decides whether a click belongs to the box in the first place.
-pub(crate) fn input_hit_col(col: u16) -> Option<usize> {
+/// Clamped rather than row-checked on purpose: the pointer routinely leaves the box while the user is
+/// still selecting inside it, and a drag that stopped extending the moment it strayed off the last row
+/// would be unusable. Above the box the selection collapses to the start of the first visible row,
+/// below it to the end of the last — which is what dragging past the end of the text means everywhere
+/// else. [`input_hit`] is the row-checked variant that decides whether a CLICK belongs to the box in
+/// the first place.
+pub(crate) fn input_hit_drag(col: u16, row: u16) -> Option<usize> {
     let g = input_geom_slot().lock().unwrap_or_else(|e| e.into_inner());
-    if g.row.width == 0 || g.cols.is_empty() {
+    if g.area.width == 0 {
         return None;
     }
-    Some(hit_index(&g.cols, g.start, col))
+    let first = g.rows.first()?;
+    let last = g.rows.last()?;
+    if row < first.y {
+        return Some(first.start);
+    }
+    if row > last.y {
+        return Some(last.start + last.cols.len().saturating_sub(1));
+    }
+    let r = g.rows.iter().find(|r| r.y == row).unwrap_or(last);
+    Some(hit_index(&r.cols, r.start, col))
 }
 
 /// Which draft char the cell at absolute column `col` belongs to, given a published column map. Pure so
@@ -137,7 +160,7 @@ pub(crate) fn input_hit_col(col: u16) -> Option<usize> {
 /// `cols[i + 1]` is where char `i` ends, so the first char whose end is past the click owns the cell the
 /// click landed on, and the caret goes ON that cell: exactly where the block cursor is then drawn. Both
 /// cells of a double-width char therefore resolve to that char, a click left of the text resolves to the
-/// start of the window, and anything past the end resolves to just after the last visible char.
+/// start of the row, and anything past the end resolves to just after the row's last char.
 pub(super) fn hit_index(cols: &[u16], start: usize, col: u16) -> usize {
     let visible = cols.len().saturating_sub(1);
     for i in 0..visible {
@@ -148,16 +171,15 @@ pub(super) fn hit_index(cols: &[u16], start: usize, col: u16) -> usize {
     start + visible
 }
 
-/// Draft index a click at (`col`, `row`) points at, or `None` when the click is not on the input row.
+/// Draft index a click at (`col`, `row`) points at, or `None` when the click is not on a composer row.
 pub(crate) fn input_hit(col: u16, row: u16) -> Option<usize> {
-    let on_row = {
-        let g = input_geom_slot().lock().unwrap_or_else(|e| e.into_inner());
-        g.row.width > 0
-            && row == g.row.y
-            && col >= g.row.x
-            && col < g.row.x.saturating_add(g.row.width)
-    };
-    on_row.then(|| input_hit_col(col)).flatten()
+    let g = input_geom_slot().lock().unwrap_or_else(|e| e.into_inner());
+    let in_x = g.area.width > 0 && col >= g.area.x && col < g.area.x.saturating_add(g.area.width);
+    if !in_x {
+        return None;
+    }
+    let r = g.rows.iter().find(|r| r.y == row)?;
+    Some(hit_index(&r.cols, r.start, col))
 }
 
 /// Where `draw_footer` last asked ratatui to park the input caret (`frame.set_cursor_position`).

--- a/src/ui/tui/retained/geom.rs
+++ b/src/ui/tui/retained/geom.rs
@@ -47,6 +47,52 @@ pub(crate) fn jump_button_rect() -> Option<Rect> {
     g.jump_button
 }
 
+/// Where the last frame put a SELECTABLE overlay's option rows, so the input thread can turn a
+/// left-click into a row index. Present only while a menu overlay (approval, question, model,
+/// sessions, palette) is painted — informational overlays wrap their text, so their screen rows do
+/// not map 1:1 to lines and they publish nothing.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct OverlayMenuGeom {
+    /// Inner rect of the overlay panel (inside the border) — option rows start at its top row.
+    pub(crate) inner: Rect,
+    /// Rows hidden above the top at last draw (the clamped scroll actually applied).
+    pub(crate) scroll: usize,
+    /// Number of PICKABLE rows. The hint line painted below them is not one — a click there is dead.
+    pub(crate) rows: usize,
+}
+
+pub(super) fn overlay_menu_slot() -> &'static Mutex<Option<OverlayMenuGeom>> {
+    static SLOT: OnceLock<Mutex<Option<OverlayMenuGeom>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(None))
+}
+
+/// Publish (or clear) the selectable-overlay geometry for this frame. Draw-thread only.
+pub(super) fn set_overlay_menu(g: Option<OverlayMenuGeom>) {
+    *overlay_menu_slot()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = g;
+}
+
+/// Menu row index a click at (`col`, `row`) points at, or `None` when no selectable overlay is on
+/// screen or the click missed its option rows (border, hint line, outside the panel).
+pub(crate) fn overlay_menu_hit(col: u16, row: u16) -> Option<usize> {
+    let g = (*overlay_menu_slot()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()))?;
+    menu_hit_index(&g, col, row)
+}
+
+/// Pure half of [`overlay_menu_hit`], separated so the mapping is testable without a terminal.
+pub(super) fn menu_hit_index(g: &OverlayMenuGeom, col: u16, row: u16) -> Option<usize> {
+    let in_x = col >= g.inner.x && col < g.inner.x.saturating_add(g.inner.width);
+    let in_y = row >= g.inner.y && row < g.inner.y.saturating_add(g.inner.height);
+    if !in_x || !in_y {
+        return None;
+    }
+    let idx = g.scroll.saturating_add((row - g.inner.y) as usize);
+    (idx < g.rows).then_some(idx)
+}
+
 /// Where the input box's typed text landed on screen at the last draw, so the input thread can turn a
 /// mouse column into a caret position in the draft.
 ///

--- a/src/ui/tui/retained/paint.rs
+++ b/src/ui/tui/retained/paint.rs
@@ -1,5 +1,5 @@
 //! Painting one frame: the transcript pane, the selection highlight, the working line, and the
-//! footer with the input row.
+//! footer with the composer — which wraps a long draft down as many rows as it needs.
 //!
 //! Everything here runs on the render thread and is a pure function of `AppState` plus the frame
 //! it is handed — which is what makes the window/caret arithmetic testable without a terminal.
@@ -8,12 +8,19 @@ use super::*;
 
 pub(super) fn draw(frame: &mut Frame<'_>, state: &mut AppState) {
     let area = frame.area();
+    // The composer GROWS DOWNWARD with the draft instead of scrolling one row sideways, so the
+    // footer's height is decided here — before the split — from the wrapped draft. `input_layout` is
+    // pure over `AppState`, so the same call that sizes the box is the one handed to `draw_footer`
+    // to paint it: the two cannot disagree by a row.
+    let layout = input_layout(state, area.width as usize, max_input_rows(area.height));
+    state.input_row_scroll = layout.scroll; // sticky across frames — see `AppState::input_row_scroll`
+    let footer_rows = FOOTER_CHROME_ROWS.saturating_add(layout.rows.len() as u16);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(FOOTER_ROWS)])
+        .constraints([Constraint::Min(1), Constraint::Length(footer_rows)])
         .split(area);
     draw_transcript(frame, chunks[0], state);
-    draw_footer(frame, chunks[1], state);
+    draw_footer(frame, chunks[1], state, &layout);
     // Rects floating ABOVE the transcript this frame. Collected here (rather than inferred later)
     // because only the draw pass knows what was actually painted — the post-draw hyperlink injector
     // writes at absolute coordinates and would otherwise print over them.
@@ -33,6 +40,19 @@ pub(super) fn draw(frame: &mut Frame<'_>, state: &mut AppState) {
     if let Ok(mut slot) = occluders_slot().lock() {
         *slot = occluders;
     }
+}
+
+/// How many text rows the composer may occupy in a terminal `height` rows tall.
+///
+/// The box grows with the draft, but it must never eat the conversation: at least
+/// `MIN_TRANSCRIPT_ROWS` are always left above it, and it never passes `MAX_INPUT_TEXT_ROWS` however
+/// tall the terminal is — past that a pasted wall of text would BE the screen.
+pub(super) fn max_input_rows(height: u16) -> usize {
+    const MIN_TRANSCRIPT_ROWS: u16 = 3;
+    let spare = height
+        .saturating_sub(FOOTER_CHROME_ROWS)
+        .saturating_sub(MIN_TRANSCRIPT_ROWS);
+    spare.clamp(1, MAX_INPUT_TEXT_ROWS) as usize
 }
 
 /// Resolve the transcript scroll for one frame. Pure so it can be unit-tested without a backend.
@@ -315,7 +335,14 @@ pub(super) fn working_line(state: &AppState) -> Vec<(String, Line<'static>)> {
     vec![(plain, Line::from(spans))]
 }
 
-pub(super) fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &mut AppState) {
+/// Paint the footer: the HUD strip, the two framing rules, and the composer's text rows between
+/// them. `layout` is the one computed in [`draw`] — it already decided how tall `area` is.
+pub(super) fn draw_footer(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    state: &mut AppState,
+    layout: &InputLayout,
+) {
     if area.height < FOOTER_ROWS || area.width == 0 {
         // No input row was painted, so retire the click map with it — a stale one would keep answering
         // hit-tests for a row that is no longer on screen.
@@ -324,12 +351,19 @@ pub(super) fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &mut AppStat
         }
         return;
     }
+    // `draw` asked for `3 + layout.rows.len()`, but a Layout under pressure can hand back less than
+    // it asked for — so paint what actually arrived rather than what was requested.
+    let text_rows = layout
+        .rows
+        .len()
+        .min(area.height.saturating_sub(FOOTER_CHROME_ROWS) as usize)
+        .max(1);
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1),
             Constraint::Length(1),
-            Constraint::Length(1),
+            Constraint::Length(text_rows as u16),
             Constraint::Length(1),
         ])
         .split(area);
@@ -392,119 +426,140 @@ pub(super) fn draw_footer(frame: &mut Frame<'_>, area: Rect, state: &mut AppStat
     ];
     hud_spans.extend(right_spans);
     frame.render_widget(Paragraph::new(Line::from(hud_spans)), rows[0]);
-    let rule = "─".repeat(width);
+    // Framing rules. When the draft is taller than the box, the rule on that side carries the count
+    // of rows hidden behind it (`↑12` / `↓3`) — without it a scrolled composer is indistinguishable
+    // from a truncated one, which is the very thing this box exists to stop.
+    let hidden_above = layout.scroll;
+    let hidden_below = layout.total.saturating_sub(layout.scroll + text_rows);
     frame.render_widget(
-        Paragraph::new(Line::styled(
-            rule.clone(),
-            Style::default().fg(Color::Indexed(box_accent)),
-        )),
+        Paragraph::new(rule_line(width, box_accent, hidden_above, '↑')),
         rows[1],
     );
-
-    // A quiet right-aligned key hint (`↵ send · Tab complete`) shown only while the draft is empty
-    // and an overlay isn't up — it must never fight the typed text or the `/`-command list for the
-    // row. Reserve its width from the typing budget so the hint and the input never overlap.
-    let hint = if state.input.draft.is_empty() && state.input.overlay.is_none() {
-        "↵ send · Tab complete"
-    } else {
-        ""
-    };
-    let hint_w = if hint.is_empty() {
-        0
-    } else {
-        console::measure_text_width(hint) + 1
-    };
-    // A `[Nimg]` chip when vision attachments are pending (Ctrl-O / dropped files) so the input box
-    // shows the attachment count — matches the classic renderer. Its width is reserved from the
-    // typing budget so it never overlaps the typed text or the caret math.
-    let imgtag = if state.input.images > 0 {
-        format!("[{}img] ", state.input.images)
-    } else {
-        String::new()
-    };
-    let imgtag_w = console::measure_text_width(&imgtag);
-    let type_budget = width.saturating_sub(3 + imgtag_w + hint_w);
-    let row = input_line(state, type_budget);
-    let InputRow {
-        shown,
-        caret_off: cursor_off,
-        start: win_start,
-        cols: char_cols,
-    } = row;
-    state.input_win_start = win_start; // sticky across frames — see `AppState::input_win_start`
-    let shown_w = console::measure_text_width(&shown);
-    // Pad between the typed text and the right-aligned hint. `3` = `❯ ` (2) + one right margin.
-    let hint_gap = width
-        .saturating_sub(3 + imgtag_w + shown_w + hint_w.saturating_sub(1))
-        .max(if hint.is_empty() { 0 } else { 1 });
-    let mut prompt_spans = vec![Span::styled(
-        "❯ ",
-        Style::default()
-            .fg(Color::Indexed(box_accent))
-            .add_modifier(Modifier::BOLD),
-    )];
-    if !imgtag.is_empty() {
-        prompt_spans.push(Span::styled(
-            imgtag,
-            Style::default().fg(Color::Indexed(crate::ui::theme::ACCENT)),
-        ));
-    }
-    prompt_spans.push(Span::styled(shown, Style::default().fg(Color::White)));
-    if !hint.is_empty() {
-        prompt_spans.push(Span::raw(" ".repeat(hint_gap)));
-        prompt_spans.push(Span::styled(
-            hint.to_string(),
-            Style::default().fg(Color::DarkGray),
-        ));
-    }
-    // Cells from the start of the row to the first char of the visible draft window: `❯ ` plus the
-    // `[Nimg]` chip. Both the highlight (row-relative) and the click map (absolute) hang off this.
-    let text_off = 2 + imgtag_w;
-    let mut prompt_line = Line::from(prompt_spans);
-    // A mouse highlight inside the box, painted the same way the transcript paints its own.
-    if let Some((from_cell, to_cell)) = sel_cells(
-        crate::ui::tui::normalized_draft_sel(state.input.sel, state.input.draft.len()),
-        win_start,
-        &char_cols,
-        text_off,
-    ) {
-        reverse_line_cols(&mut prompt_line, from_cell, to_cell);
-    }
-    frame.render_widget(Paragraph::new(prompt_line), rows[2]);
     frame.render_widget(
-        Paragraph::new(Line::styled(
-            rule,
-            Style::default().fg(Color::Indexed(box_accent)),
-        )),
+        Paragraph::new(rule_line(width, box_accent, hidden_below, '↓')),
         rows[3],
     );
+
+    let body_style = if layout.placeholder {
+        Style::default().fg(Color::DarkGray)
+    } else {
+        Style::default().fg(Color::White)
+    };
+    let sel = crate::ui::tui::normalized_draft_sel(state.input.sel, state.input.draft.len());
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(text_rows);
+    for (i, row) in layout.rows.iter().take(text_rows).enumerate() {
+        let mut spans: Vec<Span<'static>> = Vec::with_capacity(5);
+        if i == 0 {
+            spans.push(Span::styled(
+                "❯ ",
+                Style::default()
+                    .fg(Color::Indexed(box_accent))
+                    .add_modifier(Modifier::BOLD),
+            ));
+            // A `[Nimg]` chip when vision attachments are pending (Ctrl-O / dropped files) so the box
+            // shows the attachment count. Its width is baked into `layout.text_off`, so the wrap and
+            // the caret math already know about it.
+            if state.input.images > 0 {
+                spans.push(Span::styled(
+                    format!("[{}img] ", state.input.images),
+                    Style::default().fg(Color::Indexed(crate::ui::theme::ACCENT)),
+                ));
+            }
+        } else {
+            // Continuation rows are indented under the first row's text, so a wrapped prompt reads as
+            // one block instead of a ragged left edge that the `❯` no longer lines up with.
+            spans.push(Span::raw(" ".repeat(layout.text_off)));
+        }
+        spans.push(Span::styled(row.shown.clone(), body_style));
+        // A quiet right-aligned key hint (`↵ send · Tab complete`), only on the first row and only
+        // while the draft is empty — it must never fight typed text for the row.
+        if i == 0 && !layout.hint.is_empty() {
+            let used = layout.text_off + console::measure_text_width(&row.shown);
+            let gap = width
+                .saturating_sub(used + console::measure_text_width(layout.hint))
+                .max(1);
+            spans.push(Span::raw(" ".repeat(gap)));
+            spans.push(Span::styled(
+                layout.hint.to_string(),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        let mut line = Line::from(spans);
+        // A mouse highlight inside the box, painted the same way the transcript paints its own. Each
+        // row clips the draft-index range to its own slice, so a selection spanning several wrapped
+        // rows lights all of them.
+        if !layout.placeholder {
+            if let Some((from_cell, to_cell)) =
+                sel_cells(sel, row.start, &row.cols, layout.text_off)
+            {
+                reverse_line_cols(&mut line, from_cell, to_cell);
+            }
+        }
+        lines.push(line);
+    }
+    frame.render_widget(Paragraph::new(Text::from(lines)), rows[2]);
+
     // Publish where each visible char landed so the input thread can map a click to a caret position.
     if let Ok(mut slot) = input_geom_slot().lock() {
         *slot = InputGeom {
-            row: rows[2],
-            start: win_start,
-            cols: char_cols
+            area: rows[2],
+            rows: layout
+                .rows
                 .iter()
-                .map(|c| {
-                    rows[2]
-                        .x
-                        .saturating_add(text_off as u16)
-                        .saturating_add(*c as u16)
+                .take(text_rows)
+                .enumerate()
+                .map(|(i, r)| InputRowGeom {
+                    y: rows[2].y.saturating_add(i as u16),
+                    start: r.start,
+                    cols: r
+                        .cols
+                        .iter()
+                        .map(|c| {
+                            rows[2]
+                                .x
+                                .saturating_add(layout.text_off as u16)
+                                .saturating_add(*c as u16)
+                        })
+                        .collect(),
                 })
                 .collect(),
         };
     }
+    let (caret_row, caret_col) = layout.caret;
+    let caret_row = caret_row.min(text_rows.saturating_sub(1));
     let cursor_x = rows[2]
         .x
-        .saturating_add(2)
-        .saturating_add(imgtag_w as u16)
-        .saturating_add(cursor_off as u16);
-    let caret = (cursor_x.min(rows[2].right().saturating_sub(1)), rows[2].y);
+        .saturating_add(layout.text_off as u16)
+        .saturating_add(caret_col as u16);
+    let caret = (
+        cursor_x.min(rows[2].right().saturating_sub(1)),
+        rows[2].y.saturating_add(caret_row as u16),
+    );
     frame.set_cursor_position(caret);
     // Publish it so the post-draw hyperlink injector can restore the caret after moving the cursor.
     if let Ok(mut slot) = caret_slot().lock() {
         *slot = Some(caret);
     }
+}
+
+/// One framing rule of the input box. `hidden` > 0 stamps a `↑N` / `↓N` tag into the rule near its
+/// right end — the only place a scrolled composer can report what is off screen without stealing a
+/// cell from the text.
+fn rule_line(width: usize, accent: u8, hidden: usize, arrow: char) -> Line<'static> {
+    let accent_style = Style::default().fg(Color::Indexed(accent));
+    let tag = format!(" {arrow}{hidden} ");
+    let tag_w = console::measure_text_width(&tag);
+    if hidden == 0 || width < tag_w + 6 {
+        return Line::styled("─".repeat(width), accent_style);
+    }
+    Line::from(vec![
+        Span::styled("─".repeat(width - tag_w - 2), accent_style),
+        Span::styled(
+            tag,
+            Style::default().fg(Color::Indexed(crate::ui::theme::MUTED)),
+        ),
+        Span::styled("──".to_string(), accent_style),
+    ])
 }
 
 /// Row cells `[from, to)` that a draft selection covers, clipped to the window actually on screen.
@@ -528,117 +583,228 @@ pub(super) fn sel_cells(
     (to > from).then(|| (text_off + cols[from], text_off + cols[to]))
 }
 
-/// One painted input row: what fits on screen, where the caret goes, and where every visible char
-/// landed. Returned as a struct because the column map is the whole point — see [`InputGeom`].
-pub(super) struct InputRow {
-    /// The text painted after `❯ ` and the `[Nimg]` chip: the window of the draft that fits, behind the
-    /// `↵N · ` paste chip when the draft is many lines. The placeholder text when the draft is empty.
+/// One painted row of the composer: what is on it, which draft chars they are, and where each of
+/// them landed. The column map is the whole point — see [`InputGeom`].
+pub(super) struct InputRowView {
+    /// The text painted after `❯ ` (first row) or the matching indent (continuation rows). An
+    /// embedded newline is painted as a blank cell — the row break itself is the glyph.
     pub(crate) shown: String,
-    /// Display cells from the start of `shown` to the caret.
-    pub(crate) caret_off: usize,
-    /// Draft index of the first char of the visible window (`0` unless a long draft scrolled).
+    /// Draft index of the first char on this row.
     pub(crate) start: usize,
-    /// Display cells from the start of `shown` to the start of visible char `i` — i.e. draft char
-    /// `start + i` — plus one trailing entry for the cell just past the last char. Never empty.
+    /// Display cells from the start of the text area to the start of char `start + i`, plus one
+    /// trailing entry for the cell just past the last char. Never empty.
     pub(crate) cols: Vec<usize>,
 }
 
-pub(super) fn input_line(state: &AppState, budget: usize) -> InputRow {
-    if state.input.draft.is_empty() {
-        let q = if state.input.queued_count > 0 {
-            format!(" · {} queued", state.input.queued_count)
-        } else {
-            String::new()
-        };
-        // Mirror the classic footer: while working, advertise Alt+Enter (steer the RUNNING turn) and
-        // count steers the loop hasn't folded in yet — a steer has no transcript line of its own
-        // until the agent picks it up, so this counter is the only "it landed" feedback.
-        let s = match crate::core::steer::pending() {
-            0 => String::new(),
-            n => format!(" · ⤳{n}"),
-        };
-        let ph = if state.working {
-            format!("Queue · Alt+↵ steers · Esc stops{q}{s}")
-        } else {
-            format!("Type a message · / commands{q}")
-        };
-        // No draft ⇒ no chars to map: `cols` carries only the past-the-end entry, so any click on the
-        // placeholder resolves to caret 0 (which is where an empty draft's caret already is).
-        return InputRow {
-            shown: console::truncate_str(&ph, budget, "…").into_owned(),
-            caret_off: 0,
-            start: 0,
-            cols: vec![0],
-        };
+/// The composer's geometry for one frame: the wrapped draft rows that are on screen, where the caret
+/// sits among them, and how far the window is scrolled.
+///
+/// Computed ONCE per frame in [`draw`] — it is what decides the footer's height — then handed to
+/// [`draw_footer`] to paint. Pure over [`AppState`], so the arithmetic that used to be tangled up
+/// with the widget calls is testable without a terminal.
+pub(super) struct InputLayout {
+    /// Only the rows actually on screen (`scroll..scroll + max_rows` of the wrapped draft).
+    pub(crate) rows: Vec<InputRowView>,
+    /// First wrapped row on screen. `0` unless the draft is taller than the box.
+    pub(crate) scroll: usize,
+    /// Total wrapped rows in the draft, on screen or not.
+    pub(crate) total: usize,
+    /// Caret as `(index into rows, display cells from the start of the text area)`.
+    pub(crate) caret: (usize, usize),
+    /// Cells from the row's left edge to its first text cell: `❯ ` plus any `[Nimg]` chip. The same
+    /// on every row, so wrapped continuations line up under the first one.
+    pub(crate) text_off: usize,
+    /// `rows[0].shown` is the grey placeholder rather than draft text: paint it dim, map no chars.
+    pub(crate) placeholder: bool,
+    /// Right-aligned key hint for the first row. Empty unless the draft is empty.
+    pub(crate) hint: &'static str,
+}
+
+/// Display cells one draft char occupies. A newline owns a cell of its own (painted blank) so a
+/// click at the end of a line can park the caret BEFORE the break instead of at the start of the
+/// next line, and so a selection that spans it shows the break it is about to copy.
+fn draft_cellw(c: char) -> usize {
+    // The whole draft is re-wrapped on every frame, so the common case must not allocate:
+    // printable ASCII is width 1 by definition, and only the rest is worth a measuring call.
+    if c == '\n' || c == ' ' || c.is_ascii_graphic() {
+        return 1;
     }
-    // Khi draft có ≥5 dòng (paste lớn), vẫn hiện prefix compact `↵N ·` để báo hiệu,
-    // nhưng KHÔNG ẩn toàn bộ text — window quanh cursor vẫn hiện bình thường để người
-    // dùng thấy những gì vừa gõ thêm. Trước đây trả về chip cứng nên text bị ẩn.
-    let nlines = state.input.draft.iter().filter(|&&c| c == '\n').count() + 1;
-    let paste_prefix = if nlines >= 5 {
-        format!("↵{nlines} · ")
+    console::measure_text_width(&c.to_string()).max(1)
+}
+
+/// Lay a draft out over as many rows as it needs, at `width` display cells per row.
+///
+/// Two things end a row: an embedded newline (Shift+Enter, or a pasted block) and running out of
+/// width. The width break prefers the last space on the row, so a long prompt wraps as prose instead
+/// of being guillotined mid-word; a single word wider than the box still breaks hard, because the
+/// alternative is a row that never ends.
+///
+/// Always returns at least one row, and always ends one: a draft ending in a newline gets the empty
+/// trailing row the caret is sitting on.
+fn wrap_draft(draft: &[char], width: usize) -> Vec<InputRowView> {
+    let width = width.max(1);
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let (mut i, mut start, mut used) = (0usize, 0usize, 0usize);
+    // Draft index just AFTER the last space on the row being built — the preferred break point.
+    let mut last_space: Option<usize> = None;
+    while i < draft.len() {
+        let c = draft[i];
+        let cw = draft_cellw(c);
+        if used + cw > width && i > start {
+            let brk = last_space.filter(|b| *b > start && *b < i).unwrap_or(i);
+            ranges.push((start, brk));
+            start = brk;
+            used = 0;
+            last_space = None;
+            // Re-lay from the break: chars moved off the full row have to be measured again on the
+            // fresh one. `brk > start` held before the assignment, so this always advances.
+            i = brk;
+            continue;
+        }
+        used += cw;
+        i += 1;
+        if c == '\n' {
+            ranges.push((start, i));
+            start = i;
+            used = 0;
+            last_space = None;
+        } else if c == ' ' {
+            last_space = Some(i);
+        }
+    }
+    ranges.push((start, draft.len()));
+    ranges
+        .into_iter()
+        .map(|(s, e)| row_view(draft, s, e))
+        .collect()
+}
+
+/// Measure one row range into the map the painter and the hit-test both read.
+fn row_view(draft: &[char], start: usize, end: usize) -> InputRowView {
+    let mut shown = String::new();
+    let mut cols = Vec::with_capacity(end.saturating_sub(start) + 1);
+    let mut used = 0usize;
+    for &c in &draft[start..end] {
+        cols.push(used);
+        shown.push(if c == '\n' { ' ' } else { c });
+        used += draft_cellw(c);
+    }
+    // One entry past the last char, so a click beyond the text has a cell to land on.
+    cols.push(used);
+    InputRowView { shown, start, cols }
+}
+
+/// Which row the caret belongs to. A row spanning `[start, end)` owns carets `[start, end)`; the
+/// caret at the very end of the draft belongs to the last row, which is why the fallback is not an
+/// error.
+fn caret_row_of(rows: &[InputRowView], cursor: usize) -> usize {
+    for (i, r) in rows.iter().enumerate() {
+        if cursor < r.start + r.cols.len().saturating_sub(1) {
+            return i;
+        }
+    }
+    rows.len().saturating_sub(1)
+}
+
+/// The grey line shown in place of the draft when there is nothing typed.
+fn placeholder_text(state: &AppState) -> String {
+    let q = if state.input.queued_count > 0 {
+        format!(" · {} queued", state.input.queued_count)
     } else {
         String::new()
     };
-    let prefix_w = console::measure_text_width(&paste_prefix);
-    let cursor = state.input.cursor.min(state.input.draft.len());
-    // The input box is a single physical row, so render an embedded newline as a visible `↵`
-    // glyph (width 1) rather than a raw `\n` that ratatui can't lay out on one line.
-    let disp = |c: char| -> char {
-        if c == '\n' {
-            '↵'
-        } else {
-            c
-        }
+    // Mirror the classic footer: while working, advertise Alt+Enter (steer the RUNNING turn) and
+    // count steers the loop hasn't folded in yet — a steer has no transcript line of its own
+    // until the agent picks it up, so this counter is the only "it landed" feedback.
+    let s = match crate::core::steer::pending() {
+        0 => String::new(),
+        n => format!(" · ⤳{n}"),
     };
-    let cellw = |c: char| console::measure_text_width(&disp(c).to_string()).max(1);
-    // Budget for the text window shrinks by the paste prefix (e.g. `↵12 · `) so both fit on one row.
-    let text_budget = budget.saturating_sub(prefix_w);
-    let draft = &state.input.draft;
-    // ── Sticky window ──────────────────────────────────────────────────────────────────────────────
-    // Start from where the window was last frame and move it only as far as the caret forces. One cell
-    // is held back from the right edge so the block caret has somewhere to sit at the end of the text.
-    let cap = text_budget.saturating_sub(1);
-    let mut start = state.input_win_start.min(cursor);
-    // Caret past the right edge (typing, or a jump to the end) → scroll right until it fits.
-    let mut to_caret: usize = draft[start..cursor].iter().map(|&c| cellw(c)).sum();
-    while to_caret > cap && start < cursor {
-        to_caret -= cellw(draft[start]);
-        start += 1;
+    if state.working {
+        format!("Queue · Alt+↵ steers · Esc stops{q}{s}")
+    } else {
+        format!("Type a message · / commands{q}")
     }
-    // Tail no longer fills the window (after deleting, or a wider terminal) → pull it back left, so a
-    // scrolled draft never shows dead space on the right with text hidden off the left.
-    let mut tail: usize = draft[start..].iter().map(|&c| cellw(c)).sum();
-    while start > 0 {
-        let cw = cellw(draft[start - 1]);
-        if tail + cw > cap {
-            break;
-        }
-        tail += cw;
-        start -= 1;
+}
+
+/// Wrap the draft, place the caret in it, and pick the window of rows to show.
+///
+/// `width` is the full footer width; `max_rows` the tallest the box may grow (see
+/// [`max_input_rows`]). Past that the window SCROLLS by rows — but only as far as the caret forces
+/// it. Re-deriving the window from the caret every frame would pin the caret to the bottom row, so a
+/// glance back up a long paste would snap away the moment anything repainted.
+pub(super) fn input_layout(state: &AppState, width: usize, max_rows: usize) -> InputLayout {
+    let max_rows = max_rows.max(1);
+    let imgtag_w = if state.input.images > 0 {
+        console::measure_text_width(&format!("[{}img] ", state.input.images))
+    } else {
+        0
+    };
+    // `❯ ` plus the chip. Reserved on continuation rows too, so wrapped text stays in one column.
+    let text_off = 2 + imgtag_w;
+
+    if state.input.draft.is_empty() {
+        let hint = if state.input.overlay.is_none() {
+            "↵ send · Tab complete"
+        } else {
+            ""
+        };
+        let hint_w = if hint.is_empty() {
+            0
+        } else {
+            console::measure_text_width(hint) + 1
+        };
+        let budget = width.saturating_sub(text_off + hint_w + 1);
+        // No draft ⇒ no chars to map: `cols` carries only the past-the-end entry, so any click on the
+        // placeholder resolves to caret 0 (which is where an empty draft's caret already is).
+        return InputLayout {
+            rows: vec![InputRowView {
+                shown: console::truncate_str(&placeholder_text(state), budget, "…").into_owned(),
+                start: 0,
+                cols: vec![0],
+            }],
+            scroll: 0,
+            total: 1,
+            caret: (0, 0),
+            text_off,
+            placeholder: true,
+            hint,
+        };
     }
-    let mut shown = String::new();
-    let mut cols = Vec::with_capacity(text_budget + 1);
-    let mut used = 0usize;
-    for &c in &draft[start..] {
-        let cw = cellw(c);
-        if used + cw > text_budget {
-            break;
-        }
-        cols.push(prefix_w + used);
-        shown.push(disp(c));
-        used += cw;
+
+    // One cell is held back on the right so the block caret has somewhere to sit at the end of a full
+    // row, and so wrapped text never touches the frame edge.
+    let wrap_w = width.saturating_sub(text_off + 1).max(1);
+    let rows = wrap_draft(&state.input.draft, wrap_w);
+    let cursor = state.input.cursor.min(state.input.draft.len());
+    let caret_row = caret_row_of(&rows, cursor);
+    let total = rows.len();
+
+    // Sticky window: it moves only as far as the caret forces it.
+    let mut scroll = state.input_row_scroll.min(total.saturating_sub(max_rows));
+    if caret_row < scroll {
+        scroll = caret_row;
+    } else if caret_row >= scroll + max_rows {
+        scroll = caret_row + 1 - max_rows;
     }
-    // One entry past the last visible char, so a click beyond the text has a cell to land on.
-    cols.push(prefix_w + used);
-    // Re-measure the caret against the window that was actually chosen: the pull-back loop above can
-    // move `start` left after `to_caret` was computed.
-    let caret: usize = draft[start..cursor].iter().map(|&c| cellw(c)).sum();
-    // Prepend the paste-count prefix and offset the cursor position past it.
-    InputRow {
-        shown: format!("{paste_prefix}{shown}"),
-        caret_off: prefix_w + caret,
-        start,
-        cols,
+    let caret_col = rows
+        .get(caret_row)
+        .map(|r| {
+            let within = cursor.saturating_sub(r.start);
+            r.cols
+                .get(within)
+                .copied()
+                .unwrap_or_else(|| r.cols.last().copied().unwrap_or(0))
+        })
+        .unwrap_or(0);
+    let visible: Vec<InputRowView> = rows.into_iter().skip(scroll).take(max_rows).collect();
+    InputLayout {
+        caret: (caret_row.saturating_sub(scroll), caret_col),
+        rows: visible,
+        scroll,
+        total,
+        text_off,
+        placeholder: false,
+        hint: "",
     }
 }

--- a/src/ui/tui/retained/paint.rs
+++ b/src/ui/tui/retained/paint.rs
@@ -21,9 +21,14 @@ pub(super) fn draw(frame: &mut Frame<'_>, state: &mut AppState) {
     if let Some(overlay) = state.input.overlay.clone() {
         // draw_overlay clamps the requested scroll against the overlay's own visible height and
         // returns the value actually used, so a stored offset past the end snaps back next frame.
+        // It also publishes the menu hit-test geometry (selectable overlays only).
         let (scroll, rect) = draw_overlay(frame, area, &overlay, state.overlay_scroll);
         state.overlay_scroll = scroll;
         occluders.push(rect);
+    } else {
+        // No overlay this frame → no menu rows to click. Without this, a stale rect from the last
+        // open menu would keep swallowing left-clicks as phantom row picks.
+        set_overlay_menu(None);
     }
     if let Ok(mut slot) = occluders_slot().lock() {
         *slot = occluders;

--- a/src/ui/tui/retained/tests.rs
+++ b/src/ui/tui/retained/tests.rs
@@ -54,114 +54,135 @@ fn keep_sgr_drops_cursor_moves_but_keeps_colour() {
     assert_eq!(got, "ok\x1b[31mred\x1b[0m\nnext");
 }
 
-#[test]
-fn short_multiline_draft_stays_inline() {
-    let mut state = AppState::new("intro", "status");
-    state.input.draft = "x\n".chars().collect();
-    state.input.cursor = state.input.draft.len();
-
-    let InputRow {
-        shown,
-        caret_off: caret,
-        ..
-    } = input_line(&state, 40);
-
-    assert_eq!(shown, "x↵", "a short Shift+Enter draft is shown inline");
-    assert_eq!(caret, 2, "caret advances over the visible newline glyph");
-    assert!(
-        !shown.contains("lines pasted"),
-        "short text must not look like a paste chip"
-    );
-}
-
-#[test]
-fn large_multiline_draft_uses_paste_chip() {
-    // Fix: paste lớn vẫn hiện prefix compact `↵N ·` + text quanh cursor, KHÔNG ẩn toàn bộ
-    // draft bằng chip cứng. Người dùng vừa paste vừa gõ thêm phải thấy những gì họ gõ.
-    let mut state = AppState::new("intro", "status");
-    state.input.draft = "a\nb\nc\nd\ne".chars().collect();
-    state.input.cursor = state.input.draft.len();
-
-    let shown = input_line(&state, 40).shown;
-
-    // Phải có prefix báo số dòng.
-    assert!(
-        shown.starts_with("↵5 · "),
-        "paste prefix missing: {shown:?}"
-    );
-    // Text thật (ký tự cuối draft là 'e') vẫn hiện sau prefix.
-    assert!(
-        shown.contains('e'),
-        "draft text must follow the prefix: {shown:?}"
-    );
-}
-
-/// A draft of `text` with the caret at `cursor` and the window last drawn from `win_start`.
-fn input_state(text: &str, cursor: usize, win_start: usize) -> AppState {
+/// A draft of `text` with the caret at `cursor` and the box scrolled to wrapped row `row_scroll`.
+fn input_state(text: &str, cursor: usize, row_scroll: usize) -> AppState {
     let mut state = AppState::new("intro", "status");
     state.input.draft = text.chars().collect();
     state.input.cursor = cursor;
-    state.input_win_start = win_start;
+    state.input_row_scroll = row_scroll;
     state
 }
 
-#[test]
-fn window_stays_put_while_the_caret_moves_inside_it() {
-    // THE BUG: the window used to be re-derived from the caret every frame, which pinned the caret
-    // to the right edge — so ←, or a click, scrolled the whole line under a stationary cursor and
-    // you could never land on the char you aimed at. Same draft, caret walked back one char: the
-    // window must not move.
-    let long: String = ('a'..='z').cycle().take(80).collect();
-    let end = input_line(&input_state(&long, 80, 0), 20);
-    assert!(
-        end.start > 0,
-        "a draft 4x the box must scroll at all: {:?}",
-        end.shown
-    );
-    assert_eq!(
-        end.caret_off, 19,
-        "typing at the end keeps the caret at the right edge"
-    );
-
-    let back = input_line(&input_state(&long, 79, end.start), 20);
-    assert_eq!(
-        back.start, end.start,
-        "moving the caret INSIDE the window must not scroll the text"
-    );
-    assert_eq!(back.caret_off, 18, "the caret moved, not the text");
+/// Full text of a laid-out box, rows joined by `|` — enough to assert where the breaks landed.
+fn joined(layout: &InputLayout) -> String {
+    layout
+        .rows
+        .iter()
+        .map(|r| r.shown.clone())
+        .collect::<Vec<_>>()
+        .join("|")
 }
 
 #[test]
-fn window_follows_the_caret_off_either_edge() {
+fn a_long_draft_wraps_downward_instead_of_scrolling_away() {
+    // THE BUG: the box was ONE row, so everything before the window slid off the left and could not
+    // be read back or copied. A draft wider than the box must now occupy more rows, with every char
+    // of it still on screen.
     let long: String = ('a'..='z').cycle().take(80).collect();
-    // Caret left of the window (Home, or a click after scrolling) → re-anchor on the caret.
-    let home = input_line(&input_state(&long, 0, 60), 20);
-    assert_eq!(home.start, 0);
-    assert_eq!(home.caret_off, 0);
-    // Caret past the right edge (End) → scroll so it fits, one cell short of the width for the
-    // caret cell itself.
-    let end = input_line(&input_state(&long, 80, 0), 20);
-    assert_eq!(end.start, 80 - 19);
-    // Window scrolled but the draft now fits → pull back so no dead space shows on the right.
-    let short = input_line(&input_state("abc", 3, 40), 20);
-    assert_eq!(short.start, 0, "a short draft is never scrolled");
-    assert_eq!(short.shown, "abc");
+    // width 24 → text area 24 - 2 (`❯ `) - 1 (caret margin) = 21 cells per row.
+    let layout = input_layout(&input_state(&long, 80, 0), 24, 10);
+    assert!(layout.rows.len() > 1, "80 chars at 21 cells must wrap");
+    assert_eq!(layout.total, 4, "80 chars / 21 cells = 4 rows");
+    let painted: String = layout.rows.iter().map(|r| r.shown.clone()).collect();
+    assert_eq!(painted, long, "every char stays on screen, in order");
+    assert_eq!(layout.scroll, 0, "4 rows fit under a 10-row cap");
 }
 
 #[test]
-fn column_map_covers_every_visible_char_and_one_past_the_end() {
-    let row = input_line(&input_state("abc", 3, 0), 20);
+fn wrapping_breaks_on_spaces_but_still_splits_a_long_word() {
+    // Prose wraps at the last space, so a wrapped prompt reads as prose. Width 11 leaves 8 cells of
+    // text (11 - 2 for `❯ ` - 1 for the caret margin), so each word lands on its own row.
+    let layout = input_layout(&input_state("hello world again", 0, 0), 11, 10);
+    assert_eq!(joined(&layout), "hello |world |again");
+    // A single word wider than the box has no space to break on — it breaks hard rather than
+    // producing a row that never ends.
+    let layout = input_layout(&input_state("aaaaaaaaaaaaaaaa", 0, 0), 14, 10);
+    assert_eq!(joined(&layout), "aaaaaaaaaaa|aaaaa");
+}
+
+#[test]
+fn embedded_newlines_start_a_new_row() {
+    // Shift+Enter and pasted blocks break rows on their own, whatever the width. The newline keeps a
+    // cell of its own (painted blank) so a click at the end of a line lands BEFORE the break.
+    let layout = input_layout(&input_state("a\nb\nc", 5, 0), 40, 10);
+    assert_eq!(layout.rows.len(), 3);
+    assert_eq!(joined(&layout), "a |b |c");
+    assert_eq!(layout.rows[1].start, 2, "row 2 starts after the first \\n");
+    // A draft ending in a newline gets the empty row the caret is sitting on.
+    let layout = input_layout(&input_state("a\n", 2, 0), 40, 10);
+    assert_eq!(layout.rows.len(), 2);
+    assert_eq!(layout.caret, (1, 0), "caret on the fresh empty row");
+}
+
+#[test]
+fn the_caret_lands_on_the_row_that_owns_it() {
+    let layout = input_layout(&input_state("abc\ndef", 5, 0), 40, 10);
+    assert_eq!(layout.caret, (1, 1), "second row, one cell in");
+    // End of the draft: the last row, past its last char.
+    let layout = input_layout(&input_state("abc\ndef", 7, 0), 40, 10);
+    assert_eq!(layout.caret, (1, 3));
+    // On the newline itself: still the END of the first row, not the start of the second.
+    let layout = input_layout(&input_state("abc\ndef", 3, 0), 40, 10);
+    assert_eq!(layout.caret, (0, 3));
+}
+
+#[test]
+fn the_box_scrolls_by_rows_only_once_it_hits_its_ceiling() {
+    let many: String = (0..8).map(|i| format!("line{i}\n")).collect();
+    let end = many.chars().count();
+    // 9 wrapped rows (8 newline-terminated + the trailing empty one), box capped at 3.
+    let layout = input_layout(&input_state(&many, end, 0), 40, 3);
+    assert_eq!(layout.total, 9);
+    assert_eq!(layout.rows.len(), 3, "never taller than the cap");
+    assert_eq!(layout.scroll, 6, "the caret's row is the bottom one");
+    assert_eq!(layout.caret.0, 2);
+    // Caret walked back above the window → the window follows it up.
+    let layout = input_layout(&input_state(&many, 0, 6), 40, 3);
+    assert_eq!(layout.scroll, 0);
+    // Caret INSIDE the window → the window does not move, so reading back a long paste is stable.
+    let layout = input_layout(&input_state(&many, end - 1, 6), 40, 3);
     assert_eq!(
-        row.cols,
+        layout.scroll, 6,
+        "a caret already on screen must not scroll"
+    );
+}
+
+#[test]
+fn max_input_rows_leaves_the_transcript_room() {
+    assert_eq!(max_input_rows(40), 10, "capped by MAX_INPUT_TEXT_ROWS");
+    assert_eq!(max_input_rows(10), 4, "10 - 3 chrome - 3 transcript");
+    assert_eq!(max_input_rows(6), 1, "a tiny terminal still gets one row");
+    assert_eq!(max_input_rows(1), 1, "never zero");
+}
+
+#[test]
+fn an_empty_draft_is_one_placeholder_row() {
+    let layout = input_layout(&AppState::new("intro", "status"), 60, 10);
+    assert_eq!(layout.rows.len(), 1);
+    assert!(layout.placeholder);
+    assert!(layout.rows[0].shown.starts_with("Type a message"));
+    assert_eq!(
+        layout.rows[0].cols,
+        vec![0],
+        "the placeholder maps no chars, so a click on it parks the caret at 0"
+    );
+    assert_eq!(layout.hint, "↵ send · Tab complete");
+}
+
+#[test]
+fn column_map_covers_every_char_on_the_row_and_one_past_the_end() {
+    let layout = input_layout(&input_state("abc", 3, 0), 40, 10);
+    assert_eq!(
+        layout.rows[0].cols,
         vec![0, 1, 2, 3],
         "3 chars + the past-the-end cell"
     );
     // A wide char takes two cells, so the map is not a 1:1 index → column relation. `♥` is width 1;
     // use a CJK char, which every wcwidth table agrees is 2.
-    let wide = input_line(&input_state("a漢b", 3, 0), 20);
-    assert_eq!(wide.cols, vec![0, 1, 3, 4]);
+    let wide = input_layout(&input_state("a漢b", 3, 0), 40, 10);
+    assert_eq!(wide.rows[0].cols, vec![0, 1, 3, 4]);
     // Both cells of the wide char resolve to it; past the end lands after the last char.
-    let cols: Vec<u16> = wide.cols.iter().map(|c| *c as u16).collect();
+    let cols: Vec<u16> = wide.rows[0].cols.iter().map(|c| *c as u16).collect();
     assert_eq!(hit_index(&cols, 0, 1), 1, "left cell of 漢");
     assert_eq!(
         hit_index(&cols, 0, 2),
@@ -175,6 +196,31 @@ fn column_map_covers_every_visible_char_and_one_past_the_end() {
         "far right of the row → end of text"
     );
     assert_eq!(hit_index(&cols, 0, 0), 0, "first cell");
+}
+
+#[test]
+fn a_selection_spanning_wrapped_rows_lights_every_row_it_covers() {
+    // The highlight is one range of DRAFT indices but several rows of cells, so each row clips it to
+    // its own slice. Without that, only the row the drag started on would light up.
+    let layout = input_layout(&input_state("hello world again", 0, 0), 11, 10);
+    // Rows: "hello " (0..6), "world " (6..12), "again" (12..17). Select "lo world ag".
+    let sel = Some((3usize, 14usize));
+    let off = layout.text_off;
+    assert_eq!(
+        sel_cells(sel, layout.rows[0].start, &layout.rows[0].cols, off),
+        Some((off + 3, off + 6)),
+        "from the anchor to the end of the first row"
+    );
+    assert_eq!(
+        sel_cells(sel, layout.rows[1].start, &layout.rows[1].cols, off),
+        Some((off, off + 6)),
+        "the whole middle row"
+    );
+    assert_eq!(
+        sel_cells(sel, layout.rows[2].start, &layout.rows[2].cols, off),
+        Some((off, off + 2)),
+        "up to the cursor on the last row"
+    );
 }
 
 #[test]
@@ -969,4 +1015,61 @@ fn verify_line_reads_green_success() {
     };
     let row = plain(&render_verify_line(&v, 80));
     assert_eq!(row, "✓ cargo check — 0 errors · verify gate passed");
+}
+
+/// Paint one whole frame into an in-memory terminal and read the rows back as plain text. Wraps the
+/// only end-to-end check there is that the footer's height, its rules and its text rows agree — the
+/// layout arithmetic being right is no use if the widgets are handed the wrong rects.
+fn painted_rows(state: &mut AppState, w: u16, h: u16) -> Vec<String> {
+    let mut term = Terminal::new(ratatui::backend::TestBackend::new(w, h)).unwrap();
+    term.draw(|f| draw(f, state)).unwrap();
+    let buf = term.backend().buffer().clone();
+    (0..h)
+        .map(|y| {
+            let row: String = (0..w).map(|x| buf[(x, y)].symbol()).collect();
+            row.trim_end().to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn a_long_prompt_is_painted_down_the_screen_not_off_the_side() {
+    // THE BUG this box exists to fix: a prompt longer than one row scrolled sideways, so most of
+    // what you typed was hidden and there was no way to read it back — or select it to copy.
+    let mut state = AppState::new("intro", "status");
+    let prompt = "hay giup toi viet mot doan van rat dai de kiem tra xem hop nhap co xuong dong";
+    state.input.draft = prompt.chars().collect();
+    state.input.cursor = state.input.draft.len();
+    let rows = painted_rows(&mut state, 40, 12);
+    assert_eq!(rows[8], "❯ hay giup toi viet mot doan van rat");
+    assert_eq!(rows[9], "  dai de kiem tra xem hop nhap co");
+    assert_eq!(rows[10], "  xuong dong");
+    assert_eq!(rows[7], "─".repeat(40), "top rule sits above the text rows");
+    assert_eq!(rows[11], "─".repeat(40), "bottom rule closes the box");
+    // Nothing is dropped: the painted rows re-join into the prompt exactly.
+    let joined = rows[8..=10]
+        .iter()
+        .map(|r| r.trim_start_matches("❯ ").trim_start())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(joined, prompt);
+}
+
+#[test]
+fn a_draft_taller_than_the_box_stops_growing_and_says_what_is_hidden() {
+    // The box grows, but not without limit: the transcript keeps its floor, and the rule reports the
+    // rows behind it so a capped composer never reads as a truncated one.
+    let mut state = AppState::new("intro", "status");
+    let many: String = (0..14).map(|i| format!("dong so {i}\n")).collect();
+    state.input.draft = many.chars().collect();
+    state.input.cursor = 30;
+    let rows = painted_rows(&mut state, 40, 16);
+    assert_eq!(rows[5], "❯ dong so 0");
+    assert_eq!(rows[14], "  dong so 9", "10 text rows is the ceiling");
+    assert!(
+        rows[15].ends_with("↓5 ──"),
+        "the bottom rule counts the hidden rows: {:?}",
+        rows[15]
+    );
+    assert_eq!(rows[0], "intro", "the transcript keeps its floor");
 }

--- a/src/ui/tui/retained/tests.rs
+++ b/src/ui/tui/retained/tests.rs
@@ -4,6 +4,43 @@
 use super::*;
 
 #[test]
+fn overlay_menu_hit_maps_rows_scroll_and_dead_zones() {
+    let g = OverlayMenuGeom {
+        inner: Rect {
+            x: 10,
+            y: 5,
+            width: 40,
+            height: 6,
+        },
+        scroll: 2,
+        rows: 7,
+    };
+    // Top visible row is index `scroll`; the mapping is row-relative plus scroll.
+    assert_eq!(menu_hit_index(&g, 10, 5), Some(2), "top row, left edge");
+    assert_eq!(
+        menu_hit_index(&g, 49, 9),
+        Some(6),
+        "last pickable row, right edge"
+    );
+    // Inside the panel but past the pickable rows (the hint line) → dead, not a phantom pick.
+    assert_eq!(menu_hit_index(&g, 20, 10), None, "hint row is not pickable");
+    // Outside the panel on every side → None (the click belongs to the transcript handler).
+    assert_eq!(menu_hit_index(&g, 9, 6), None, "left of the panel");
+    assert_eq!(menu_hit_index(&g, 50, 6), None, "right of the panel");
+    assert_eq!(menu_hit_index(&g, 20, 4), None, "above the panel");
+    assert_eq!(menu_hit_index(&g, 20, 11), None, "below the panel");
+    // The published slot round-trips, and clearing it kills the hit-test (stale-rect guard).
+    set_overlay_menu(Some(g));
+    assert_eq!(overlay_menu_hit(10, 5), Some(2));
+    set_overlay_menu(None);
+    assert_eq!(
+        overlay_menu_hit(10, 5),
+        None,
+        "no overlay → no phantom picks"
+    );
+}
+
+#[test]
 fn sanitizes_terminal_control_sequences() {
     let got = sanitize_text("ok\x1b[2J\x1b[31mred\x1b[0m\nnext\r");
     assert_eq!(got, "okred\nnext");

--- a/src/ui/tui/retained/widgets.rs
+++ b/src/ui/tui/retained/widgets.rs
@@ -59,12 +59,24 @@ pub(super) fn draw_overlay(
     let visible = inner.height as usize;
     let max_scroll = lines.len().saturating_sub(visible);
     let clamped = scroll.min(max_scroll);
-    frame.render_widget(
+    // A SELECTABLE overlay is a menu: its rows must stay one screen row each so a mouse click can be
+    // mapped back to a row index (`overlay_menu_hit`). Long rows are clipped at the panel edge, not
+    // wrapped — wrapping would break the row↔line mapping the hit-test depends on. Informational
+    // overlays (no selection) keep wrapping and publish no geometry.
+    let selectable = overlay.selected.is_some();
+    let paragraph = if selectable {
+        Paragraph::new(lines).scroll((clamped.min(u16::MAX as usize) as u16, 0))
+    } else {
         Paragraph::new(lines)
             .wrap(Wrap { trim: false })
-            .scroll((clamped.min(u16::MAX as usize) as u16, 0)),
+            .scroll((clamped.min(u16::MAX as usize) as u16, 0))
+    };
+    frame.render_widget(paragraph, inner);
+    set_overlay_menu(selectable.then_some(OverlayMenuGeom {
         inner,
-    );
+        scroll: clamped,
+        rows: overlay.lines.len(),
+    }));
     (clamped, rect)
 }
 


### PR DESCRIPTION
Release PR. Everything on `dev` since v0.6.5 — 17 commits, 5 merged PRs.

## Headline this cycle

**The composer wraps a long prompt down instead of hiding it.** The input box was ONE physical row, so a prompt wider than it scrolled sideways: unreadable, and (the hit-test being single-row) unselectable, which left `Ctrl-C` taking *all* of it as the only way to get your own text back. It now grows downward — word-wrapped rows, a mouse selection that spans them, a 10-row ceiling that never leaves the transcript under 3, and hidden-row counts on the framing rules (`↑12` / `↓3`) so a capped box does not read as a truncated one. ↑/↓ walk the rows of a multi-line draft before they mean history recall.

**`aizen agent --image <PATH>`.** Vision was REPL-only. The headless entry point can now attach PNG/JPEG/GIF/WebP to the first user message, files read *before* the endpoint is resolved and an unreadable path failing the run rather than being silently dropped.

Also landed since 0.6.5 (see `CHANGELOG.md` for the full section):

- `aizen config set` reaches the twelve keys it could not, plus `--{subagent,summarizer,oracle,apply}-provider`
- `aizen agent --save-session` and `--effort auto|low|…|max`
- LLM round-trip reduction on the read / done-gate / re-read paths
- loop, LLM-client, subagent and MCP hardening
- clickable menus for approvals and clarify questions
- `/effort`'s top stop set auto-detect instead of `ultimate` — fixed

## Release

`Cargo.toml` 0.6.5 → 0.6.6, `CHANGELOG.md` cut to `## [0.6.6] — 2026-08-21`.

The manifest sat at 0.6.5 from that release until now, so every build cut from `dev` in between also reported `aizen 0.6.5`. This is the first bump since.

## Testing

- `cargo test --bin aizen` — 1721 passed, 0 failed
- PR #22 was green on all 8 checks (3 OS build+test, 3 dense build, fmt+clippy, cla) before merging to `dev`
- the release build was installed locally and used

Tag `v0.6.6` goes on the merge commit, which triggers `release.yml` to build and publish the platform binaries.
